### PR TITLE
Correct typo kuberentes->kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Available Commands:
 Flags:
   -h, --help                     help for virtual-kubelet
       --kubeconfig string        config file (default is $HOME/.kube/config)
-      --namespace string         kuberentes namespace (default is 'all')
+      --namespace string         kubernetes namespace (default is 'all')
       --nodename string          kubernetes node name (default "virtual-kubelet")
       --os string                Operating System (Linux/Windows) (default "Linux")
       --provider string          cloud provider
@@ -184,7 +184,7 @@ type Provider interface {
 	Capacity() v1.ResourceList
 
 	// NodeConditions returns a list of conditions (Ready, OutOfDisk, etc), which is polled periodically to update the node status
-	// within Kuberentes.
+	// within Kubernetes.
 	NodeConditions() []v1.NodeCondition
 
 	// OperatingSystem returns the operating system the provider is for.

--- a/providers/azure/aci.go
+++ b/providers/azure/aci.go
@@ -273,7 +273,7 @@ func (p *ACIProvider) Capacity() v1.ResourceList {
 }
 
 // NodeConditions returns a list of conditions (Ready, OutOfDisk, etc), for updates to the node status
-// within Kuberentes.
+// within Kubernetes.
 func (p *ACIProvider) NodeConditions() []v1.NodeCondition {
 	// TODO: Make these dynamic and augment with custom ACI specific conditions of interest
 	return []v1.NodeCondition{
@@ -321,7 +321,7 @@ func (p *ACIProvider) NodeConditions() []v1.NodeCondition {
 }
 
 // NodeAddresses returns a list of addresses for the node status
-// within Kuberentes.
+// within Kubernetes.
 func (p *ACIProvider) NodeAddresses() []v1.NodeAddress {
 	// TODO: Make these dynamic and augment with custom ACI specific conditions of interest
 	return []v1.NodeAddress{
@@ -333,7 +333,7 @@ func (p *ACIProvider) NodeAddresses() []v1.NodeAddress {
 }
 
 // NodeDaemonEndpoints returns NodeDaemonEndpoints for the node status
-// within Kuberentes.
+// within Kubernetes.
 func (p *ACIProvider) NodeDaemonEndpoints() *v1.NodeDaemonEndpoints {
 	return &v1.NodeDaemonEndpoints{
 		KubeletEndpoint: v1.DaemonEndpoint{

--- a/providers/hypersh/hypersh.go
+++ b/providers/hypersh/hypersh.go
@@ -368,7 +368,7 @@ func (p *HyperProvider) Capacity() v1.ResourceList {
 }
 
 // NodeConditions returns a list of conditions (Ready, OutOfDisk, etc), for updates to the node status
-// within Kuberentes.
+// within Kubernetes.
 func (p *HyperProvider) NodeConditions() []v1.NodeCondition {
 	// TODO: Make these dynamic and augment with custom hyper.sh specific conditions of interest
 	return []v1.NodeCondition{
@@ -417,13 +417,13 @@ func (p *HyperProvider) NodeConditions() []v1.NodeCondition {
 }
 
 // NodeAddresses returns a list of addresses for the node status
-// within Kuberentes.
+// within Kubernetes.
 func (p *HyperProvider) NodeAddresses() []v1.NodeAddress {
 	return nil
 }
 
 // NodeDaemonEndpoints returns NodeDaemonEndpoints for the node status
-// within Kuberentes.
+// within Kubernetes.
 func (p *HyperProvider) NodeDaemonEndpoints() *v1.NodeDaemonEndpoints {
 	return nil
 }

--- a/providers/web/broker.go
+++ b/providers/web/broker.go
@@ -176,7 +176,7 @@ func (p *BrokerProvider) NodeConditions() []v1.NodeCondition {
 }
 
 // NodeAddresses returns a list of addresses for the node status
-// within Kuberentes.
+// within Kubernetes.
 func (p *BrokerProvider) NodeAddresses() []v1.NodeAddress {
 	var nodeAddresses []v1.NodeAddress
 	err := p.doGetRequest("/nodeAddresses", &nodeAddresses)
@@ -190,7 +190,7 @@ func (p *BrokerProvider) NodeAddresses() []v1.NodeAddress {
 }
 
 // NodeDaemonEndpoints returns NodeDaemonEndpoints for the node status
-// within Kuberentes.
+// within Kubernetes.
 func (p *BrokerProvider) NodeDaemonEndpoints() *v1.NodeDaemonEndpoints {
 	return &v1.NodeDaemonEndpoints{
 		KubeletEndpoint: v1.DaemonEndpoint{

--- a/vkubelet/provider.go
+++ b/vkubelet/provider.go
@@ -39,15 +39,15 @@ type Provider interface {
 	Capacity() v1.ResourceList
 
 	// NodeConditions returns a list of conditions (Ready, OutOfDisk, etc), which is polled periodically to update the node status
-	// within Kuberentes.
+	// within Kubernetes.
 	NodeConditions() []v1.NodeCondition
 
 	// NodeAddresses returns a list of addresses for the node status
-	// within Kuberentes.
+	// within Kubernetes.
 	NodeAddresses() []v1.NodeAddress
 
 	// NodeDaemonEndpoints returns NodeDaemonEndpoints for the node status
-	// within Kuberentes.
+	// within Kubernetes.
 	NodeDaemonEndpoints() *v1.NodeDaemonEndpoints
 
 	// OperatingSystem returns the operating system the provider is for.


### PR DESCRIPTION
This seems to be a common typo, possibly exacerbated by copy-paste of comment strings. I spotted it in the README.md at first, so I fixed that and then checked the rest of the code and fixed a few more. They are all in comments or documentation, so there's no code issue.

FYI, there's still some in the vendor directory, but I haven't fixed those as they'd get replaced by any new `go get` I think:

```
$ ack uberentes
vendor/k8s.io/apimachinery/hack/godep-deps.sh
20:# 2. godep restore based on k8s.io/kuberentes provided manifest

vendor/k8s.io/client-go/CHANGELOG.md
120:* Included bug fixes in k8s.io/kuberentes release-1.5 branch, up to

vendor/k8s.io/client-go/kubernetes/fake/register.go
64://     clientsetscheme "k8s.io/client-go/kuberentes/scheme"

vendor/k8s.io/client-go/kubernetes/scheme/register.go
64://     clientsetscheme "k8s.io/client-go/kuberentes/scheme"
```
Sorry, this isn't the most exciting commit in the world :-(