### PR TITLE
Add quotes for azure example.toml

### DIFF
--- a/providers/azure/example.toml
+++ b/providers/azure/example.toml
@@ -3,6 +3,6 @@
 Region = "westus"
 ResourceGroup = "virtual-kubeletrg"
 OperatingSystem = "Linux"
-CPU = 100
-Memory = 100Gi
-Pods = 50
+CPU = "100"
+Memory = "100Gi"
+Pods = "50"


### PR DESCRIPTION
When not having quotes, I ran into the following errors:

* 2018/01/17 16:33:14 Near line 7 (last key parsed ''): expected a top-level item to end with a newline, comment, or EOF, but got 'G' instead
* 2018/01/17 16:41:20 toml: cannot load TOML value of type int64 into a Go string