### PR TITLE
Fixes #73 - illegal base64 data

### DIFF
--- a/providers/azure/aci.go
+++ b/providers/azure/aci.go
@@ -367,13 +367,9 @@ func (p *ACIProvider) getImagePullSecrets(pod *v1.Pod) ([]aci.ImageRegistryCrede
 		// TODO: Check if secret type is v1.SecretTypeDockercfg and use DockerConfigKey instead of hardcoded value
 		// TODO: Check if secret type is v1.SecretTypeDockerConfigJson and use DockerConfigJsonKey to determine if it's in json format
 		// TODO: Return error if it's not one of these two types
-		repoDataB64, ok := secret.Data[".dockercfg"]
+		repoData, ok := secret.Data[".dockercfg"]
 		if !ok {
 			return ips, fmt.Errorf("no dockercfg present in secret")
-		}
-		repoData, err := base64.StdEncoding.DecodeString(string(repoDataB64))
-		if err != nil {
-			return ips, err
 		}
 
 		var ac AuthConfig
@@ -477,7 +473,7 @@ func (p *ACIProvider) getVolumes(pod *v1.Pod) ([]aci.Volume, error) {
 		// Handle the case for the EmptyDir.
 		if v.EmptyDir != nil {
 			volumes = append(volumes, aci.Volume{
-				Name: v.Name,
+				Name:     v.Name,
 				EmptyDir: map[string]interface{}{},
 			})
 			continue


### PR DESCRIPTION
The data being returned by the k8s client-go library is not in base64 format, it's trying to base64 decode json