### PR TITLE
Fix scheduling for Windows example

### DIFF
--- a/examples/iis-pod.yaml
+++ b/examples/iis-pod.yaml
@@ -18,7 +18,6 @@ spec:
     - containerPort: 443
       name: https
   dnsPolicy: Default
-  nodeName: virtual-kubelet-aciconnector-win
   automountServiceAccountToken: false
   tolerations:
   - key: azure.com/aci


### PR DESCRIPTION
There shouldn't be a nodename selector. That prevents it from working in recent builds configured with `az aks install-connector`