### PR TITLE
Adding supported regions for Azure Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The best description is "Kubernetes API on top, programmable back."
     + [Adding a New Provider via the Provider Interface](#adding-a-new-provider-via-the-provider-interface)
 * [Testing](#testing)
     + [Testing the Azure Provider Client](#testing-the-azure-provider-client)
-* [Known quirks and workarounds](#known-quirks-and-workaroundss)
+* [Known quirks and workarounds](#known-quirks-and-workarounds)
 * [Contributing](#contributing)
 
 ## How It Works


### PR DESCRIPTION
Based on the region availability for ACI (https://docs.microsoft.com/en-us/azure/container-instances/container-instances-quotas#region-availability), I made the following changes to make sure we only deploy ACI instances where it's supported. Fixes (avoids?) #91. 

Error message when using `westus2`:

```
$ helm install charts/virtual-kubelet -f values-linux-19.yaml

NAME:   fun-cheetah
LAST DEPLOYED: Sat Feb 10 12:04:10 2018
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1/Secret
NAME                         TYPE    DATA  AGE
fun-cheetah-virtual-kubelet  Opaque  3     3s

==> v1beta1/Deployment
NAME                         DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
fun-cheetah-virtual-kubelet  1        1        1           0          3s

==> v1/Pod(related)
NAME                                          READY  STATUS             RESTARTS  AGE
fun-cheetah-virtual-kubelet-5dd4cf6d8c-xrjdq  0/1    ContainerCreating  0         3s


NOTES:
The virtual kubelet is getting deployed on your cluster.

To verify that virtual kubelet has started, run:

  kubectl --namespace=default get pods -l "app=fun-cheetah-virtual-kubelet"

$ k get po
NAME                                                READY     STATUS    RESTARTS   AGE
fun-cheetah-virtual-kubelet-5dd4cf6d8c-xrjdq        0/1       Error     2          34s

$ k logs fun-cheetah-virtual-kubelet-5dd4cf6d8c-xrjdq
2018/02/10 20:04:45 Region westus2 is invalid. Current supported regions are: westeurope, westus, eastus, and southeastasia
```

