### PR TITLE
Adding support for ACI DNS name labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ a `virtual-kubelet` node.
 * Environment variables
 * Public IPs
 * kubectl logs
+* DNS name labels
 
 ## Current Limitations
 
@@ -115,6 +116,10 @@ You can find detailed instructions on how to set it up and how to test it in the
 
 The Azure connector can use a configuration file specified by the `--provider-config` flag.
 The config file is in TOML format, and an example lives in `providers/azure/example.toml`.
+
+#### More Details
+
+See the [ACI Readme](providers/azure/README.md)
 
 ### Hyper.sh Provider
 

--- a/providers/azure/aci.go
+++ b/providers/azure/aci.go
@@ -26,6 +26,8 @@ import (
 // The service account secret mount path.
 const serviceAccountSecretMountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
 
+const virtualKubeletDNSNameLabel = "virtualkubelet.io/dnsnamelabel"
+
 // ACIProvider implements the virtual-kubelet provider interface and communicates with Azure's ACI APIs.
 type ACIProvider struct {
 	aciClient          *aci.Client
@@ -230,6 +232,10 @@ func (p *ACIProvider) CreatePod(pod *v1.Pod) error {
 		containerGroup.ContainerGroupProperties.IPAddress = &aci.IPAddress{
 			Ports: ports,
 			Type:  "Public",
+		}
+
+		if dnsNameLabel := pod.Annotations[virtualKubeletDNSNameLabel]; dnsNameLabel != "" {
+			containerGroup.ContainerGroupProperties.IPAddress.DNSNameLabel = dnsNameLabel
 		}
 	}
 

--- a/providers/azure/client/aci/client.go
+++ b/providers/azure/client/aci/client.go
@@ -10,8 +10,8 @@ import (
 const (
 	// BaseURI is the default URI used for compute services.
 	BaseURI    = "https://management.azure.com"
-	userAgent  = "virtual-kubelet/azure-arm-aci/2017-12-01"
-	apiVersion = "2017-12-01-preview"
+	userAgent  = "virtual-kubelet/azure-arm-aci/2018-02-01"
+	apiVersion = "2018-02-01-preview"
 
 	containerGroupURLPath                    = "subscriptions/{{.subscriptionId}}/resourceGroups/{{.resourceGroup}}/providers/Microsoft.ContainerInstance/containerGroups/{{.containerGroupName}}"
 	containerGroupListURLPath                = "subscriptions/{{.subscriptionId}}/providers/Microsoft.ContainerInstance/containerGroups"

--- a/providers/azure/client/aci/types.go
+++ b/providers/azure/client/aci/types.go
@@ -172,9 +172,10 @@ type ImageRegistryCredential struct {
 
 // IPAddress is IP address for the container group.
 type IPAddress struct {
-	Ports []Port `json:"ports,omitempty"`
-	Type  string `json:"type,omitempty"`
-	IP    string `json:"ip,omitempty"`
+	Ports        []Port `json:"ports,omitempty"`
+	Type         string `json:"type,omitempty"`
+	IP           string `json:"ip,omitempty"`
+	DNSNameLabel string `json:"dnsNameLabel,omitempty"`
 }
 
 // Logs is the logs.


### PR DESCRIPTION
![vkdns](https://user-images.githubusercontent.com/87996/36290704-8e8571f8-127b-11e8-9260-2ca73bcb3f72.gif)

It's a little bit unclear where the docs for adding the virtual-kubelet annotation should go… I added it to the ACI readme - let me know if there's a more appropriate place for it. 