### PR TITLE
updated createCertAndKey.sh added -w0 in base64

### DIFF
--- a/scripts/createCertAndKey.sh
+++ b/scripts/createCertAndKey.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # Generate cert and key for chart
 openssl req -newkey rsa:4096 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem -subj "/C=US/ST=CA/L=virtualkubelet/O=virtualkubelet/OU=virtualkubelet/CN=virtualkubelet"
-cert=$(base64 cert.pem)
-key=$(base64 key.pem)
+cert=$(base64 cert.pem -w0)
+key=$(base64 key.pem -w0)


### PR DESCRIPTION
I had to add no wrapping in base64 when using bash on windows  (-w0 in base64) other wise commands fails and cert isn't properly formatted