### PR TITLE
fix "Hypersh provider breaks the build on Windows"

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -225,7 +225,7 @@
 [[projects]]
   name = "github.com/hyperhq/hypercli"
   packages = ["cliconfig","daemon/graphdriver","image","image/v1","layer","opts","pkg/archive","pkg/chrootarchive","pkg/fileutils","pkg/homedir","pkg/httputils","pkg/idtools","pkg/ioutils","pkg/jsonlog","pkg/jsonmessage","pkg/longpath","pkg/mflag","pkg/plugins","pkg/pools","pkg/promise","pkg/random","pkg/reexec","pkg/stringid","pkg/system","pkg/tarsum","pkg/term","pkg/term/windows","pkg/urlutil","pkg/version","reference","registry"]
-  revision = "3e4e4fa373cbf8672bded67688b4821cd30b37f9"
+  revision = "29217d318cab52815518a1126d57ca010de83e4d"
 
 [[projects]]
   name = "github.com/hyperhq/libcompose"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -54,9 +54,9 @@
   version = "1.6.0"
 
 [[constraint]]
-  name = "github.com/hyperhq/hypercli"
-  revision = "3e4e4fa373cbf8672bded67688b4821cd30b37f9"
-
-[[constraint]]
   name = "k8s.io/client-go"
   version = "6.0.0"
+
+[[constraint]]
+  name = "github.com/hyperhq/hypercli"
+  revision = "29217d318cab52815518a1126d57ca010de83e4d"

--- a/vendor/github.com/hyperhq/hypercli/pkg/term/windows/ansi_reader.go
+++ b/vendor/github.com/hyperhq/hypercli/pkg/term/windows/ansi_reader.go
@@ -136,14 +136,14 @@ func readInputEvents(fd uintptr, maxBytes int) ([]winterm.INPUT_RECORD, error) {
 
 // KeyEvent Translation Helpers
 
-var arrowKeyMapPrefix = map[winterm.WORD]string{
+var arrowKeyMapPrefix = map[uint16]string{
 	winterm.VK_UP:    "%s%sA",
 	winterm.VK_DOWN:  "%s%sB",
 	winterm.VK_RIGHT: "%s%sC",
 	winterm.VK_LEFT:  "%s%sD",
 }
 
-var keyMapPrefix = map[winterm.WORD]string{
+var keyMapPrefix = map[uint16]string{
 	winterm.VK_UP:     "\x1B[%sA",
 	winterm.VK_DOWN:   "\x1B[%sB",
 	winterm.VK_RIGHT:  "\x1B[%sC",
@@ -207,7 +207,7 @@ func keyToString(keyEvent *winterm.KEY_EVENT_RECORD, escapeSequence []byte) stri
 }
 
 // formatVirtualKey converts a virtual key (e.g., up arrow) into the appropriate ANSI string.
-func formatVirtualKey(key winterm.WORD, controlState winterm.DWORD, escapeSequence []byte) string {
+func formatVirtualKey(key uint16, controlState uint32, escapeSequence []byte) string {
 	shift, alt, control := getControlKeys(controlState)
 	modifier := getControlKeysModifier(shift, alt, control)
 
@@ -223,7 +223,7 @@ func formatVirtualKey(key winterm.WORD, controlState winterm.DWORD, escapeSequen
 }
 
 // getControlKeys extracts the shift, alt, and ctrl key states.
-func getControlKeys(controlState winterm.DWORD) (shift, alt, control bool) {
+func getControlKeys(controlState uint32) (shift, alt, control bool) {
 	shift = 0 != (controlState & winterm.SHIFT_PRESSED)
 	alt = 0 != (controlState & (winterm.LEFT_ALT_PRESSED | winterm.RIGHT_ALT_PRESSED))
 	control = 0 != (controlState & (winterm.LEFT_CTRL_PRESSED | winterm.RIGHT_CTRL_PRESSED))


### PR DESCRIPTION
fix issue https://github.com/virtual-kubelet/virtual-kubelet/issues/125

# issue

```
$ go build -v
github.com/virtual-kubelet/virtual-kubelet/vendor/github.com/hyperhq/hypercli/pkg/term/windows
# github.com/virtual-kubelet/virtual-kubelet/vendor/github.com/hyperhq/hypercli/pkg/term/windows
vendor\github.com\hyperhq\hypercli\pkg\term\windows\ansi_reader.go:139:29: undefined: winterm.WORD
vendor\github.com\hyperhq\hypercli\pkg\term\windows\ansi_reader.go:146:24: undefined: winterm.WORD
vendor\github.com\hyperhq\hypercli\pkg\term\windows\ansi_reader.go:210:27: undefined: winterm.WORD
vendor\github.com\hyperhq\hypercli\pkg\term\windows\ansi_reader.go:210:54: undefined: winterm.DWORD
vendor\github.com\hyperhq\hypercli\pkg\term\windows\ansi_reader.go:226:34: undefined: winterm.DWORD
```

# after fix

> build in git bash on windows

```
$ go build -v
$ ls virtual-kubelet.exe
virtual-kubelet.exe

```