### PR TITLE
Make Fargate provider available in 3 additional AWS regions

### DIFF
--- a/providers/aws/fargate/region.go
+++ b/providers/aws/fargate/region.go
@@ -12,6 +12,9 @@ var (
 	// FargateRegions are AWS regions where Fargate is available.
 	FargateRegions = Regions{
 		"us-east-1",
+		"us-east-2",
+		"us-west-2",
+		"eu-west-1",
 	}
 )
 


### PR DESCRIPTION
Fixes https://github.com/virtual-kubelet/virtual-kubelet/issues/180.

Added unit tests:

```
Running tool: /usr/local/go/bin/go test -timeout 30s github.com/virtual-kubelet/virtual-kubelet/providers/aws/fargate -run ^TestAvailableRegions$

ok  	github.com/virtual-kubelet/virtual-kubelet/providers/aws/fargate	0.037s
Success: Tests passed.
```