### PR TITLE
Add the kubernetes.io/hostname label to the VK node

### DIFF
--- a/vkubelet/vkubelet.go
+++ b/vkubelet/vkubelet.go
@@ -147,7 +147,7 @@ func (s *Server) registerNode() error {
 				"type":                  "virtual-kubelet",
 				"kubernetes.io/role":    "agent",
 				"beta.kubernetes.io/os": strings.ToLower(s.provider.OperatingSystem()),
-
+				"kubernetes.io/hostname": s.nodeName,
 				"alpha.service-controller.kubernetes.io/exclude-balancer": "true",
 			},
 		},


### PR DESCRIPTION
"kubernetes.io/hostname" is a [well-known label for node](https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetesiohostname)
It is used in nodeSelector and nodeAffinity for pod scheduling.
In our current examples, we use nodeName to assign the pod to the VK node without the scheduler. If we use a wrong node in the pod, like #186, it's hard to troubleshoot since the pod will disappear in a few seconds.
With the hostname label, we can use the nodeSelector to ask the scheduler to assign the pod to VK node.
```
nodeSelector:
  kubernetes.io/hostname: <vk-node>
```

If the node name is wrong in the pod spec, the pod will stay in the "Pending" state, and the scheduler will create the "FailedScheduling" events in `kubectl describe po <pod-name>`:
```
Events:
  Type     Reason            Age                From               Message
  ----     ------            ----               ----               -------
  Warning  FailedScheduling  11m (x5 over 13m)  default-scheduler  No nodes are available that match all of the predicates: MatchNodeSelector (3), NodeNetworkUnavailable (1).
  Warning  FailedScheduling  11m (x7 over 13m)  default-scheduler  No nodes are available that match all of the predicates: MatchNodeSelector (3), NodeNetworkUnavailable (2).
  Warning  FailedScheduling  3m (x28 over 13m)  default-scheduler  No nodes are available that match all of the predicates: MatchNodeSelector (3).
```