### PR TITLE
[AWS Fargate] Execution role required if CloudWatch log group is specified

### DIFF
--- a/providers/aws/config.go
+++ b/providers/aws/config.go
@@ -102,6 +102,9 @@ func (p *FargateProvider) loadConfig(r io.Reader) error {
 	if config.OperatingSystem != providers.OperatingSystemLinux {
 		return fmt.Errorf("Fargate does not support operating system %v", config.OperatingSystem)
 	}
+	if config.CloudWatchLogGroupName != "" && config.ExecutionRoleArn == "" {
+		return fmt.Errorf("Execution role required if CloudWatch log group is specified")
+	}
 
 	// Validate advertised capacity.
 	if q, err = resource.ParseQuantity(config.CPU); err != nil {

--- a/providers/aws/fargate.toml
+++ b/providers/aws/fargate.toml
@@ -32,7 +32,7 @@ ExecutionRoleArn = ""
 
 # Amazon CloudWatch log group name used to store container logs. Optional.
 # If omitted, container logs will not be available.
-# If specified, execution role is required.
+# If specified, an execution role with access to CloudWatch logs is required.
 CloudWatchLogGroupName = ""
 
 # AWS Fargate platform version. Optional. Defaults to "LATEST".

--- a/providers/aws/fargate.toml
+++ b/providers/aws/fargate.toml
@@ -32,6 +32,7 @@ ExecutionRoleArn = ""
 
 # Amazon CloudWatch log group name used to store container logs. Optional.
 # If omitted, container logs will not be available.
+# If specified, execution role is required.
 CloudWatchLogGroupName = ""
 
 # AWS Fargate platform version. Optional. Defaults to "LATEST".


### PR DESCRIPTION
Fixes https://github.com/virtual-kubelet/virtual-kubelet/issues/193.
I still need to verify with e2e tests.
~~Shall I add some unit tests for configuration file validation?~~