### PR TITLE
Add go fmt test for project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,3 +24,6 @@ jobs:
       - run:
           name: Tests
           command: V=1 CI=1 SKIP_AWS_E2E=1 make test
+      - run:
+          name: Gofmt
+          command: bash scripts/verify-gofmt.sh

--- a/scripts/verify-gofmt.sh
+++ b/scripts/verify-gofmt.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -o errexit
+
+find_files() {
+  find ../ -not -wholename '*/vendor/*' -name '*.go'
+}
+
+diff=$(find_files | xargs gofmt -d -s 2>&1)
+if [[ -n "${diff}" ]]; then
+  echo "${diff}" >&2
+  echo >&2
+  read -ra go_version <<< "$(go version)"
+  echo "Please use ${go_version[2]} and run gofmt for above files." >&2
+  exit 1
+fi


### PR DESCRIPTION
Add gofmt test. Because different go version has different go fmt/vet/lint, if we want have unified code format, must specify a uniform go version for the project and providers.