### PR TITLE
Fix Azure File secret names to match k8s azureFile volume secrets

### DIFF
--- a/providers/azure/aci.go
+++ b/providers/azure/aci.go
@@ -630,8 +630,8 @@ func (p *ACIProvider) getVolumes(pod *v1.Pod) ([]aci.Volume, error) {
 				AzureFile: &aci.AzureFileVolume{
 					ShareName:          v.AzureFile.ShareName,
 					ReadOnly:           v.AzureFile.ReadOnly,
-					StorageAccountName: string(secret.Data["StorageAccountName"]),
-					StorageAccountKey:  string(secret.Data["StorageAccountKey"]),
+					StorageAccountName: string(secret.Data["azurestorageaccountname"]),
+					StorageAccountKey:  string(secret.Data["azurestorageaccountkey"]),
 				},
 			})
 			continue


### PR DESCRIPTION
The Azure provider is currently using different keys in the Azure File share secrets compared to the Azure File volumes in k8s. Making them consistent.

https://docs.microsoft.com/en-us/azure/aks/azure-files-volume#create-kubernetes-secret