### PR TITLE
Changed s.namespace with corev1.NamespaceAll

### DIFF
--- a/vkubelet/vkubelet.go
+++ b/vkubelet/vkubelet.go
@@ -211,7 +211,7 @@ func (s *Server) Run() error {
 			FieldSelector: fields.OneTermEqualSelector("spec.nodeName", s.nodeName).String(),
 		}
 
-		pods, err := s.k8sClient.CoreV1().Pods(s.namespace).List(opts)
+		pods, err := s.k8sClient.CoreV1().Pods(corev1.NamespaceAll).List(opts)
 		if err != nil {
 			log.Fatal("Failed to list pods", err)
 		}
@@ -219,7 +219,7 @@ func (s *Server) Run() error {
 		s.reconcile()
 
 		opts.ResourceVersion = pods.ResourceVersion
-		s.podWatcher, err = s.k8sClient.CoreV1().Pods(s.namespace).Watch(opts)
+		s.podWatcher, err = s.k8sClient.CoreV1().Pods(corev1.NamespaceAll).Watch(opts)
 		if err != nil {
 			log.Fatal("Failed to watch pods", err)
 		}


### PR DESCRIPTION
This should enable Virtual Kubelet to watch all namespaces.

NOTE:
`make safebuild` works, but `make build` or `make test` doesn't due to the below:

```
# github.com/virtual-kubelet/virtual-kubelet/providers/cri
providers/cri/cri.go:809:9: undefined: syscall.Sysinfo_t
providers/cri/cri.go:810:9: undefined: syscall.Sysinfo
# github.com/virtual-kubelet/virtual-kubelet/vendor/github.com/vmware/vic/lib/apiservers/engine/network
vendor/github.com/vmware/vic/lib/apiservers/engine/network/utils.go:62:12: undefined: netlink.LinkByName
vendor/github.com/vmware/vic/lib/apiservers/engine/network/utils.go:64:12: undefined: netlink.LinkByAlias
vendor/github.com/vmware/vic/lib/apiservers/engine/network/utils.go:281:12: undefined: netlink.LinkByName
vendor/github.com/vmware/vic/lib/apiservers/engine/network/utils.go:286:36: undefined: netlink.FAMILY_V4
```