### PR TITLE
Add AWS ap-northeast-1 (Tokyo) region to Fargate

### DIFF
--- a/providers/aws/fargate/region.go
+++ b/providers/aws/fargate/region.go
@@ -11,10 +11,11 @@ type Regions []string
 var (
 	// FargateRegions are AWS regions where Fargate is available.
 	FargateRegions = Regions{
+		"ap-northeast-1",
+		"eu-west-1",
 		"us-east-1",
 		"us-east-2",
 		"us-west-2",
-		"eu-west-1",
 	}
 )
 


### PR DESCRIPTION
AWS Fargate is now available in ap-northeast-1 (Tokyo) region.