### PR TITLE
mock provider: read a section of config

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,6 +67,11 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
+	// read default node name from environment variable.
+	// it can be overwritten by cli flags if specified.
+	if os.Getenv("DEFAULT_NODE_NAME") != "" {
+		nodeName = os.Getenv("DEFAULT_NODE_NAME")
+	}
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.


### PR DESCRIPTION
* read nodeName from environment variable
* using nodeName to locate config section

In this way: we can create a bunch of VK pods via StatefulSet, and expose Pod_Name to VK contains environment variable via DownwardAPI. All VK pods share a single configmap, and locate its own config parameter via it's name.

With this PR, we can use a single VK StatefulSet and a ConfigMap files to simulate a bunch of heterogenous nodes.  

example yaml files and config files are like:

```
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: virtual-kubelet-set
  # TODO: determine the namespace
  namespace: default
spec:
  serviceName: "virtual-kubelet-set"
  replicas: 2
  selector:
      matchLabels:
        app: virtual-kubelet-set
  template:
    metadata:
      labels:
        app: virtual-kubelet-set
    spec:
      containers:
        - name: virtual-kubelet
          image: virtual-kubelet:v0.3
          command: [ "/usr/bin/virtual-kubelet"]
          args:
            - --provider
            - mock
            # Add a "mock" taint to the VK node.
            # Only our regular jobs pods can tolerate this taint
            # This can prevent VK pod been scheduled to a VK node
            - --taint
            - mock
            - --provider-config
            - /etc/config/configs.json
          env:
            - name: NODE_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
          volumeMounts:
            - name: config-volume
              mountPath: /etc/config
      volumes:
        - name: config-volume
          configMap:
            name: vk-config

```

configs.json:
```
{
  "virtual-kubelet-set-0":
  {
    "cpu":"5",
    "memory":"5Gi",
    "pods":"5",
  },
  "virtual-kubelet-set-1":
  {
    "cpu":"10",
    "memory":"10Gi",
    "pods":"10"
  }
}
```