### PR TITLE
Updating aci api version

### DIFF
--- a/providers/azure/client/aci/client.go
+++ b/providers/azure/client/aci/client.go
@@ -10,8 +10,8 @@ import (
 const (
 	// BaseURI is the default URI used for compute services.
 	baseURI    = "https://management.azure.com"
-	userAgent  = "virtual-kubelet/azure-arm-aci/2018-02-01"
-	apiVersion = "2018-02-01-preview"
+	userAgent  = "virtual-kubelet/azure-arm-aci/2018-06-01"
+	apiVersion = "2018-06-01"
 
 	containerGroupURLPath                    = "subscriptions/{{.subscriptionId}}/resourceGroups/{{.resourceGroup}}/providers/Microsoft.ContainerInstance/containerGroups/{{.containerGroupName}}"
 	containerGroupListURLPath                = "subscriptions/{{.subscriptionId}}/providers/Microsoft.ContainerInstance/containerGroups"


### PR DESCRIPTION
The aci provider is using a quite old version of the
aci API. This PR updates it to the most recent version.

Fixes: #263