### PR TITLE
Fix bug in exec command retrieval

### DIFF
--- a/vkubelet/apiserver.go
+++ b/vkubelet/apiserver.go
@@ -79,7 +79,7 @@ func ApiServerHandlerExec(w http.ResponseWriter, req *http.Request) {
 	supportedStreamProtocols := strings.Split(req.Header.Get("X-Stream-Protocol-Version"), ",")
 
 	q := req.URL.Query()
-	command := q.Get("command")
+	command := q["command"]
 
 	// streamOpts := &remotecommand.Options{
 	// 	Stdin:  (q.Get("input") == "1"),
@@ -99,5 +99,5 @@ func ApiServerHandlerExec(w http.ResponseWriter, req *http.Request) {
 	idleTimeout := time.Second * 30
 	streamCreationTimeout := time.Second * 30
 
-	remotecommand.ServeExec(w, req, p, fmt.Sprintf("%s-%s", namespace, pod), "", container, []string{command}, streamOpts, idleTimeout, streamCreationTimeout, supportedStreamProtocols)
+	remotecommand.ServeExec(w, req, p, fmt.Sprintf("%s-%s", namespace, pod), "", container, command, streamOpts, idleTimeout, streamCreationTimeout, supportedStreamProtocols)
 }


### PR DESCRIPTION
The exec command as extracted from the query comprises only the first
part of the command and does not include potentially supplied
parameters. E.g.,
  $ kubectl exec pod -- ls -t /usr
  > command: ls

This change fixes the problem by moving away from the Query.Get API.
  $ kubectl exec pod -- ls -t /usr
  > command: [ls -t /usr]