### PR TITLE
ACI Provider: Adding Liveness/Readiness probes to ACI sdk

### DIFF
--- a/providers/azure/client/aci/client_test.go
+++ b/providers/azure/client/aci/client_test.go
@@ -217,6 +217,147 @@ func TestListContainerGroup(t *testing.T) {
 	}
 }
 
+func TestCreateContainerGroupWithLivenessProbe(t *testing.T) {
+	uid := uuid.New()
+	congainerGroupName := containerGroup + "-" + uid.String()[0:6]
+	cg, err := client.CreateContainerGroup(resourceGroup, congainerGroupName, ContainerGroup{
+		Location: location,
+		ContainerGroupProperties: ContainerGroupProperties{
+			OsType: Linux,
+			Containers: []Container{
+				{
+					Name: "nginx",
+					ContainerProperties: ContainerProperties{
+						Image:   "nginx",
+						Command: []string{"nginx", "-g", "daemon off;"},
+						Ports: []ContainerPort{
+							{
+								Protocol: ContainerNetworkProtocolTCP,
+								Port:     80,
+							},
+						},
+						Resources: ResourceRequirements{
+							Requests: &ResourceRequests{
+								CPU:        1,
+								MemoryInGB: 1,
+							},
+							Limits: &ResourceLimits{
+								CPU:        1,
+								MemoryInGB: 1,
+							},
+						},
+						LivenessProbe: &ContainerProbe{
+							HTTPGet: &ContainerHTTPGetProbe{
+								Port: 80,
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cg.Name != congainerGroupName {
+		t.Fatalf("resource group name is %s, expected %s", cg.Name, congainerGroupName)
+	}
+}
+
+func TestCreateContainerGroupFailsWithLivenessProbeMissingPort(t *testing.T) {
+	uid := uuid.New()
+	congainerGroupName := containerGroup + "-" + uid.String()[0:6]
+	_, err := client.CreateContainerGroup(resourceGroup, congainerGroupName, ContainerGroup{
+		Location: location,
+		ContainerGroupProperties: ContainerGroupProperties{
+			OsType: Linux,
+			Containers: []Container{
+				{
+					Name: "nginx",
+					ContainerProperties: ContainerProperties{
+						Image:   "nginx",
+						Command: []string{"nginx", "-g", "daemon off;"},
+						Ports: []ContainerPort{
+							{
+								Protocol: ContainerNetworkProtocolTCP,
+								Port:     80,
+							},
+						},
+						Resources: ResourceRequirements{
+							Requests: &ResourceRequests{
+								CPU:        1,
+								MemoryInGB: 1,
+							},
+							Limits: &ResourceLimits{
+								CPU:        1,
+								MemoryInGB: 1,
+							},
+						},
+						LivenessProbe: &ContainerProbe{
+							HTTPGet: &ContainerHTTPGetProbe{},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected failure")
+	}
+}
+
+func TestCreateContainerGroupWithReadinessProbe(t *testing.T) {
+	uid := uuid.New()
+	congainerGroupName := containerGroup + "-" + uid.String()[0:6]
+	cg, err := client.CreateContainerGroup(resourceGroup, congainerGroupName, ContainerGroup{
+		Location: location,
+		ContainerGroupProperties: ContainerGroupProperties{
+			OsType: Linux,
+			Containers: []Container{
+				{
+					Name: "nginx",
+					ContainerProperties: ContainerProperties{
+						Image:   "nginx",
+						Command: []string{"nginx", "-g", "daemon off;"},
+						Ports: []ContainerPort{
+							{
+								Protocol: ContainerNetworkProtocolTCP,
+								Port:     80,
+							},
+						},
+						Resources: ResourceRequirements{
+							Requests: &ResourceRequests{
+								CPU:        1,
+								MemoryInGB: 1,
+							},
+							Limits: &ResourceLimits{
+								CPU:        1,
+								MemoryInGB: 1,
+							},
+						},
+						ReadinessProbe: &ContainerProbe{
+							HTTPGet: &ContainerHTTPGetProbe{
+								Port: 80,
+								Path: "/",
+							},
+							InitialDelaySeconds: 5,
+							SuccessThreshold:    3,
+							FailureThreshold:    5,
+							TimeoutSeconds:      120,
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cg.Name != congainerGroupName {
+		t.Fatalf("resource group name is %s, expected %s", cg.Name, congainerGroupName)
+	}
+}
+
 func TestDeleteContainerGroup(t *testing.T) {
 	err := client.DeleteContainerGroup(resourceGroup, containerGroup)
 	if err != nil {

--- a/providers/azure/client/aci/client_test.go
+++ b/providers/azure/client/aci/client_test.go
@@ -294,7 +294,9 @@ func TestCreateContainerGroupFailsWithLivenessProbeMissingPort(t *testing.T) {
 							},
 						},
 						LivenessProbe: &ContainerProbe{
-							HTTPGet: &ContainerHTTPGetProbe{},
+							HTTPGet: &ContainerHTTPGetProbe{
+								Path: "/",
+							},
 						},
 					},
 				},
@@ -304,6 +306,7 @@ func TestCreateContainerGroupFailsWithLivenessProbeMissingPort(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected failure")
 	}
+	t.Fatal(err)
 }
 
 func TestCreateContainerGroupWithReadinessProbe(t *testing.T) {

--- a/providers/azure/client/aci/client_test.go
+++ b/providers/azure/client/aci/client_test.go
@@ -306,7 +306,6 @@ func TestCreateContainerGroupFailsWithLivenessProbeMissingPort(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected failure")
 	}
-	t.Fatal(err)
 }
 
 func TestCreateContainerGroupWithReadinessProbe(t *testing.T) {

--- a/providers/azure/client/aci/types.go
+++ b/providers/azure/client/aci/types.go
@@ -121,6 +121,8 @@ type ContainerProperties struct {
 	InstanceView         ContainerPropertiesInstanceView `json:"instanceView,omitempty"`
 	Resources            ResourceRequirements            `json:"resources,omitempty"`
 	VolumeMounts         []VolumeMount                   `json:"volumeMounts,omitempty"`
+	LivenessProbe        *ContainerProbe                 `json:"livenessProbe,omitempty"`
+	ReadinessProbe       *ContainerProbe                 `json:"readinessProbe,omitempty"`
 }
 
 // ContainerPropertiesInstanceView is the instance view of the container instance. Only valid in response.
@@ -142,8 +144,9 @@ type ContainerState struct {
 
 // EnvironmentVariable is the environment variable to set within the container instance.
 type EnvironmentVariable struct {
-	Name  string `json:"name,omitempty"`
-	Value string `json:"value,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Value  string `json:"value,omitempty"`
+	Secure string `json:"secureValue,omitempty"`
 }
 
 // Event is a container group or container instance event.
@@ -292,4 +295,28 @@ type ExecRequest struct {
 type ExecResponse struct {
 	WebSocketUri string `json:"webSocketUri,omitempty"`
 	Password     string `json:"password,omitempty"`
+}
+
+// ContainerProbe is a probe definition that can be used for Liveness
+// or Readiness checks.
+type ContainerProbe struct {
+	Exec                *ContainerExecProbe    `json:"exec,omitempty"`
+	HTTPGet             *ContainerHTTPGetProbe `json:"httpGet,omitempty"`
+	InitialDelaySeconds int32                  `json:"initialDelaySeconds,omitempty"`
+	Period              int32                  `json:"periodSeconds,omitempty"`
+	FailureThreshold    int32                  `json:"failureThreshold,omitempty"`
+	SuccessThreshold    int32                  `json:"successThreshold,omitempty"`
+	TimeoutSeconds      int32                  `json:"timeoutSeconds,omitempty"`
+}
+
+// ContainerExecProbe defines a command based probe
+type ContainerExecProbe struct {
+	Command []string `json:"command,omitempty"`
+}
+
+// ContainerHTTPGetProbe defines an HTTP probe
+type ContainerHTTPGetProbe struct {
+	Port   int    `json:"port"`
+	Path   string `json:"path,omitempty"`
+	Scheme string `json:"scheme,omitempty"`
 }

--- a/providers/azure/client/aci/types.go
+++ b/providers/azure/client/aci/types.go
@@ -144,9 +144,9 @@ type ContainerState struct {
 
 // EnvironmentVariable is the environment variable to set within the container instance.
 type EnvironmentVariable struct {
-	Name   string `json:"name,omitempty"`
-	Value  string `json:"value,omitempty"`
-	Secure string `json:"secureValue,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Value       string `json:"value,omitempty"`
+	SecureValue string `json:"secureValue,omitempty"`
 }
 
 // Event is a container group or container instance event.


### PR DESCRIPTION
This PR expands the ACI SDK to include both Readiness and Liveness Probes in `ContainerProperties` type in the ACI SDK.  Also adds `SecureValue` to the `EnvironmentVariable` type.

Fixes: #266