### PR TITLE
Enabling Liveness and Readiness Probes in ACI Provider

### DIFF
--- a/providers/azure/aci_test.go
+++ b/providers/azure/aci_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -407,4 +408,128 @@ func prepareMocks() (*AADMock, *ACIMock, *ACIProvider, error) {
 
 func ptrQuantity(q resource.Quantity) *resource.Quantity {
 	return &q
+}
+
+func TestCreatePodWithLivenessProbe(t *testing.T) {
+	_, aciServerMocker, provider, err := prepareMocks()
+
+	if err != nil {
+		t.Fatal("Unable to prepare the mocks", err)
+	}
+
+	podName := "pod-" + uuid.New().String()
+	podNamespace := "ns-" + uuid.New().String()
+
+	aciServerMocker.OnCreate = func(subscription, resourceGroup, containerGroup string, cg *aci.ContainerGroup) (int, interface{}) {
+		assert.Equal(t, fakeSubscription, subscription, "Subscription doesn't match")
+		assert.Equal(t, fakeResourceGroup, resourceGroup, "Resource group doesn't match")
+		assert.NotNil(t, cg, "Container group is nil")
+		assert.Equal(t, podNamespace+"-"+podName, containerGroup, "Container group name is not expected")
+		assert.NotNil(t, cg.ContainerGroupProperties, "Container group properties should not be nil")
+		assert.NotNil(t, cg.ContainerGroupProperties.Containers, "Containers should not be nil")
+		assert.Equal(t, 1, len(cg.ContainerGroupProperties.Containers), "1 Container is expected")
+		assert.Equal(t, "nginx", cg.ContainerGroupProperties.Containers[0].Name, "Container nginx is expected")
+		assert.NotNil(t, cg.Containers[0].LivenessProbe, "Liveness probe expected")
+		assert.Equal(t, cg.Containers[0].LivenessProbe.InitialDelaySeconds, 10, "Initial Probe Delay doesn't match")
+		assert.Equal(t, cg.Containers[0].LivenessProbe.Period, 5, "Probe Period doesn't match")
+		assert.Equal(t, cg.Containers[0].LivenessProbe.TimeoutSeconds, 60, "Probe Timeout doesn't match")
+		assert.Equal(t, cg.Containers[0].LivenessProbe.SuccessThreshold, 3, "Probe Success Threshold doesn't match")
+		assert.Equal(t, cg.Containers[0].LivenessProbe.FailureThreshold, 5, "Probe Failure Threshold doesn't match")
+		assert.NotNil(t, cg.Containers[0].LivenessProbe.HTTPGet, "Expected an HTTP Get Probe")
+
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: podNamespace,
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					v1.Container{
+						Name: "nginx",
+						LivenessProbe: &v1.Probe{
+							Handler: v1.Handler{
+								HTTPGet: &v1.HTTPGetAction{
+									Port: intstr.FromString("8080"),
+									Path: "/",
+								},
+							},
+							InitialDelaySeconds: 10,
+							PeriodSeconds:       5,
+							TimeoutSeconds:      60,
+							SuccessThreshold:    3,
+							FailureThreshold:    5,
+						},
+					},
+				},
+			},
+		}
+
+		if err := provider.CreatePod(pod); err != nil {
+			t.Fatal("Failed to create pod", err)
+		}
+
+		return http.StatusOK, cg
+	}
+}
+
+func TestCreatePodWithReadinessProbe(t *testing.T) {
+	_, aciServerMocker, provider, err := prepareMocks()
+
+	if err != nil {
+		t.Fatal("Unable to prepare the mocks", err)
+	}
+
+	podName := "pod-" + uuid.New().String()
+	podNamespace := "ns-" + uuid.New().String()
+
+	aciServerMocker.OnCreate = func(subscription, resourceGroup, containerGroup string, cg *aci.ContainerGroup) (int, interface{}) {
+		assert.Equal(t, fakeSubscription, subscription, "Subscription doesn't match")
+		assert.Equal(t, fakeResourceGroup, resourceGroup, "Resource group doesn't match")
+		assert.NotNil(t, cg, "Container group is nil")
+		assert.Equal(t, podNamespace+"-"+podName, containerGroup, "Container group name is not expected")
+		assert.NotNil(t, cg.ContainerGroupProperties, "Container group properties should not be nil")
+		assert.NotNil(t, cg.ContainerGroupProperties.Containers, "Containers should not be nil")
+		assert.Equal(t, 1, len(cg.ContainerGroupProperties.Containers), "1 Container is expected")
+		assert.Equal(t, "nginx", cg.ContainerGroupProperties.Containers[0].Name, "Container nginx is expected")
+		assert.NotNil(t, cg.Containers[0].ReadinessProbe, "Readiness probe expected")
+		assert.Equal(t, cg.Containers[0].ReadinessProbe.InitialDelaySeconds, 10, "Initial Probe Delay doesn't match")
+		assert.Equal(t, cg.Containers[0].ReadinessProbe.Period, 5, "Probe Period doesn't match")
+		assert.Equal(t, cg.Containers[0].ReadinessProbe.TimeoutSeconds, 60, "Probe Timeout doesn't match")
+		assert.Equal(t, cg.Containers[0].ReadinessProbe.SuccessThreshold, 3, "Probe Success Threshold doesn't match")
+		assert.Equal(t, cg.Containers[0].ReadinessProbe.FailureThreshold, 5, "Probe Failure Threshold doesn't match")
+		assert.NotNil(t, cg.Containers[0].ReadinessProbe.HTTPGet, "Expected an HTTP Get Probe")
+
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: podNamespace,
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					v1.Container{
+						Name: "nginx",
+						ReadinessProbe: &v1.Probe{
+							Handler: v1.Handler{
+								HTTPGet: &v1.HTTPGetAction{
+									Port: intstr.FromString("8080"),
+									Path: "/",
+								},
+							},
+							InitialDelaySeconds: 10,
+							PeriodSeconds:       5,
+							TimeoutSeconds:      60,
+							SuccessThreshold:    3,
+							FailureThreshold:    5,
+						},
+					},
+				},
+			},
+		}
+
+		if err := provider.CreatePod(pod); err != nil {
+			t.Fatal("Failed to create pod", err)
+		}
+
+		return http.StatusOK, cg
+	}
 }


### PR DESCRIPTION
ACI now supports defining liveness and readiness probes. This PR enables this in the ACI provider. 