### PR TITLE
Fix several bugs in the VNET

### DIFF
--- a/providers/azure/aci.go
+++ b/providers/azure/aci.go
@@ -457,8 +457,8 @@ func (p *ACIProvider) amendVnetResources(containerGroup *aci.ContainerGroup) {
 
 	containerGroup.NetworkProfile = &aci.NetworkProfileDefinition{ID: p.networkProfile}
 
-	containerGroup.ContainerGroupProperties.Containers = append(containerGroup.ContainerGroupProperties.Containers, *(getKubeProxyContainerSpec(p.clusterCIDR)))
-	containerGroup.ContainerGroupProperties.Volumes = append(containerGroup.ContainerGroupProperties.Volumes, *(getKubeProxyVolumeSpec(p.masterURI)))
+	//containerGroup.ContainerGroupProperties.Containers = append(containerGroup.ContainerGroupProperties.Containers, *(getKubeProxyContainerSpec(p.clusterCIDR)))
+	//containerGroup.ContainerGroupProperties.Volumes = append(containerGroup.ContainerGroupProperties.Volumes, *(getKubeProxyVolumeSpec(p.masterURI)))
 }
 
 func getKubeProxyContainerSpec(clusterCIDR string) *aci.Container {

--- a/providers/azure/aci.go
+++ b/providers/azure/aci.go
@@ -40,7 +40,7 @@ const (
 
 	// KubeProxy SideCar Container
 	kubeProxyContainerName  = "vk-side-car-kube-proxy"
-	kubeProxyImageName		= "k8s-gcrio.azureedge.net/hyperkube-amd64:v1.8.2"
+	kubeProxyImageName      = "k8s-gcrio.azureedge.net/hyperkube-amd64:v1.8.2"
 	kubeConfigDir	        = "/etc/kube-proxy"
 	kubeConfigFile          = "kubeconfig"
 	kubeConfigSecretVolume  = "vk-side-car-kubeconfig-secret-volume"

--- a/providers/azure/aci.go
+++ b/providers/azure/aci.go
@@ -78,6 +78,8 @@ var validAciRegions = []string{
 	"southeastasia",
 	"westus2",
 	"northeurope",
+	"eastus2euap",
+	"westcentralus",
 }
 
 // isValidACIRegion checks to make sure we're using a valid ACI region

--- a/providers/azure/acsCredential.go
+++ b/providers/azure/acsCredential.go
@@ -9,14 +9,15 @@ import (
 
 // AcsCredential represents the credential file for ACS
 type AcsCredential struct {
-	Cloud          string `json:"cloud"`
-	TenantID       string `json:"tenantId"`
-	SubscriptionID string `json:"subscriptionId"`
-	ClientID       string `json:"aadClientId"`
-	ClientSecret   string `json:"aadClientSecret"`
-	ResourceGroup  string `json:"resourceGroup"`
-	Region         string `json:"location"`
-	VNetName       string `json:"vnetName"`
+	Cloud             string `json:"cloud"`
+	TenantID          string `json:"tenantId"`
+	SubscriptionID    string `json:"subscriptionId"`
+	ClientID          string `json:"aadClientId"`
+	ClientSecret      string `json:"aadClientSecret"`
+	ResourceGroup     string `json:"resourceGroup"`
+	Region            string `json:"location"`
+	VNetName          string `json:"vnetName"`
+	VNetResourceGroup string `json:"vnetResourceGroup"`
 }
 
 // NewAcsCredential returns an AcsCredential struct from file path

--- a/providers/azure/client/network/subnet_test.go
+++ b/providers/azure/client/network/subnet_test.go
@@ -19,24 +19,32 @@ func TestCreateGetSubnet(t *testing.T) {
 	}
 	ensureVnet(t, t.Name())
 
-	if err := c.CreateOrUpdateSubnet(resourceGroup, t.Name(), subnet); err != nil {
-		t.Fatal(err)
-	}
-
-	s, err := c.GetSubnet(resourceGroup, t.Name(), subnet.Name)
+	s1, err := c.CreateOrUpdateSubnet(resourceGroup, t.Name(), subnet)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s.Name != subnet.Name {
+	if s1 == nil {
+		t.Fatal("create subnet should return subnet")
+	}
+	if s1.ID == "" {
+		t.Fatal("create subnet should return subnet.ID")
+	}
+
+	var s2 *Subnet
+	s2, err = c.GetSubnet(resourceGroup, t.Name(), subnet.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s2.Name != subnet.Name {
 		t.Fatal("got unexpected subnet")
 	}
-	if s.Properties.AddressPrefix != subnet.Properties.AddressPrefix {
-		t.Fatalf("got unexpected address prefix: %s", s.Properties.AddressPrefix)
+	if s2.Properties.AddressPrefix != subnet.Properties.AddressPrefix {
+		t.Fatalf("got unexpected address prefix: %s", s2.Properties.AddressPrefix)
 	}
-	if len(s.Properties.Delegations) != 1 {
-		t.Fatalf("got unexpected delgations: %v", s.Properties.Delegations)
+	if len(s2.Properties.Delegations) != 1 {
+		t.Fatalf("got unexpected delgations: %v", s2.Properties.Delegations)
 	}
-	if s.Properties.Delegations[0].Name != subnet.Properties.Delegations[0].Name {
-		t.Fatalf("got unexpected delegation: %v", s.Properties.Delegations[0])
+	if s2.Properties.Delegations[0].Name != subnet.Properties.Delegations[0].Name {
+		t.Fatalf("got unexpected delegation: %v", s2.Properties.Delegations[0])
 	}
 }


### PR DESCRIPTION
1. nodeName is used in setupNetworkProfile before set
2. Use vnetResourceGroup instead of AKS resource group to get VNet
3. Location is not set when creating network profile
4. networkProfile.ID is not set properly
5. Update the CreateOrUpdate functions for subnet and profile to return a pointer of the object.
6. Add the kube-proxy side car container skeleton.