### PR TITLE
Remove `env` with  from secret template 

### DIFF
--- a/charts/virtual-kubelet/templates/secret.yaml
+++ b/charts/virtual-kubelet/templates/secret.yaml
@@ -5,7 +5,7 @@ metadata:
 {{ include "vk.labels" . | indent 2 }}
 type: Opaque
 data:
-{{- if (not .Values.env.apiserverCert) and (not .Values.env.apiserverKey) }}
+{{- if (not .Values.apiserverCert) and (not .Values.apiserverKey) }}
 {{- $ca := genCA "virtual-kubelet-ca" 3650 }}
 {{- $cn := printf "%s-virtual-kubelet-apiserver" .Release.Name }}
 {{- $altName1 := printf "%s-virtual-kubelet-apiserver.%s" .Release.Name .Release.Namespace }}
@@ -14,8 +14,8 @@ data:
   cert.pem: {{ b64enc $cert.Cert }}
   key.pem: {{ b64enc $cert.Key }}
 {{- else }}
-  cert.pem: {{ quote .Values.env.apiserverCert }}
-  key.pem: {{ quote .Values.env.apiserverKey }}
+  cert.pem: {{ quote .Values.apiserverCert }}
+  key.pem: {{ quote .Values.apiserverKey }}
 {{- end }}
 {{- if eq .Values.provider "azure" }}
 {{- with .Values.providers.azure }}


### PR DESCRIPTION
When #258 was merged, there was an omission of `env` from the values.yaml, but it was still referenced in the secrets template. This caused rendering issues. Updated the secret template, as the direction was to remove that env block. 