### PR TITLE
Added centralus, eastus2,  australiaeast to Azure ACI provide

### DIFF
--- a/providers/azure/aci.go
+++ b/providers/azure/aci.go
@@ -60,12 +60,15 @@ type AuthConfig struct {
 
 // See https://azure.microsoft.com/en-us/status/ for valid regions.
 var validAciRegions = []string{
-	"westeurope",
-	"westus",
+	"centralus",
 	"eastus",
-	"southeastasia",
+	"eastus2",
+	"westus",
 	"westus2",
 	"northeurope",
+	"westeurope",
+	"southeastasia",
+	"australiaeast"
 }
 
 // isValidACIRegion checks to make sure we're using a valid ACI region

--- a/providers/azure/aci.go
+++ b/providers/azure/aci.go
@@ -68,7 +68,7 @@ var validAciRegions = []string{
 	"northeurope",
 	"westeurope",
 	"southeastasia",
-	"australiaeast"
+	"australiaeast",
 }
 
 // isValidACIRegion checks to make sure we're using a valid ACI region


### PR DESCRIPTION
I needed Sydney. I've added centralus, eastus2,  australiaeast to match valid aci regions as [documented](https://azure.microsoft.com/en-gb/global-infrastructure/services/). I've also updated azure-cli to match.

https://github.com/Azure/azure-cli/pull/6988