### PR TITLE
bugfix: use pointer in for loop

### DIFF
--- a/manager/resource.go
+++ b/manager/resource.go
@@ -85,7 +85,7 @@ func (rm *ResourceManager) SetPods(pods *v1.PodList) {
 	for k, p := range pods.Items {
 		rm.pods[rm.getStoreKey(p.Namespace, p.Name)] = &pods.Items[k]
 
-		rm.incrementRefCounters(&p)
+		rm.incrementRefCounters(&pods.Items[k])
 	}
 }
 


### PR DESCRIPTION
This is a bug fix: the `p` variable is re-used in each for-loop iteration, we can not take the pointer of `p`.

This bug has a very serious impact: if Pod watcher connection is closed unexpectedly, it will trigger yet another pod list, which will list all pods from API server and execute the following two function:

```
s.resourceManager.SetPods(pods)
s.reconcile()
```
However, this bug makes resourceManager only add one pod, instead of all pods listed from API Server (because variable `p` is re-used in each for-loop iteration). So, pods that are not added to resourceManager will get deleted by the following code.
```
for _, pod := range providerPods {
		// Delete pods that don't exist in Kubernetes
		if p := s.resourceManager.GetPod(pod.Namespace, pod.Name); p == nil || p.DeletionTimestamp != nil {
			log.Printf("Deleting pod '%s'\n", pod.Name)
			if err := s.deletePod(pod); err != nil {
				log.Printf("Error deleting pod '%s': %s\n", pod.Name, err)
				continue
			}
		}
	}
```