### PR TITLE
If --taint is specified, set the taint value to empty

### DIFF
--- a/examples/busyecho.yaml
+++ b/examples/busyecho.yaml
@@ -27,3 +27,5 @@ spec:
   tolerations:
   - key: virtual-kubelet.io/provider
     operator: Exists
+  - key: azure.com/aci
+    effect: NoSchedule

--- a/examples/iis-pod.yaml
+++ b/examples/iis-pod.yaml
@@ -29,3 +29,5 @@ spec:
   tolerations:
   - key: virtual-kubelet.io/provider
     operator: Exists
+  - key: azure.com/aci
+    effect: NoSchedule

--- a/examples/nanoserver.yaml
+++ b/examples/nanoserver.yaml
@@ -18,3 +18,5 @@ spec:
   tolerations:
   - key: virtual-kubelet.io/provider
     operator: Exists
+  - key: azure.com/aci
+    effect: NoSchedule

--- a/examples/nginx-pod.yaml
+++ b/examples/nginx-pod.yaml
@@ -21,3 +21,5 @@ spec:
   tolerations:
   - key: virtual-kubelet.io/provider
     operator: Exists
+  - key: azure.com/aci
+    effect: NoSchedule

--- a/examples/pause.yaml
+++ b/examples/pause.yaml
@@ -25,3 +25,5 @@ spec:
   tolerations:
   - key: virtual-kubelet.io/provider
     operator: Exists
+  - key: azure.com/aci
+    effect: NoSchedule

--- a/vkubelet/vkubelet.go
+++ b/vkubelet/vkubelet.go
@@ -81,13 +81,16 @@ func New(nodeName, operatingSystem, namespace, kubeConfig, provider, providerCon
 	internalIP := os.Getenv("VKUBELET_POD_IP")
 
 	var defaultTaintKey string
+	var defaultTaintValue string
 	if taintKey != "" {
 		defaultTaintKey = taintKey
+		defaultTaintValue = ""
 	} else {
 		defaultTaintKey = "virtual-kubelet.io/provider"
+		defaultTaintValue = provider
 	}
 	vkTaintKey := getEnv("VKUBELET_TAINT_KEY", defaultTaintKey)
-	vkTaintValue := getEnv("VKUBELET_TAINT_VALUE", provider)
+	vkTaintValue := getEnv("VKUBELET_TAINT_VALUE", defaultTaintValue)
 	vkTaintEffectEnv := getEnv("VKUBELET_TAINT_EFFECT", "NoSchedule")
 	var vkTaintEffect corev1.TaintEffect
 	switch vkTaintEffectEnv {


### PR DESCRIPTION
Otherwise, the image is not backward compatible with the previous examples.
Add the old tolerations into the examples to make it backward compatible during the switch
#316 