### PR TITLE
Move 'az provider register' to 'Configure your Azure account' section.

### DIFF
--- a/providers/azure/README.md
+++ b/providers/azure/README.md
@@ -111,6 +111,12 @@ First let's identify your Azure subscription and save it for use later on in the
     $env:AZURE_SUBSCRIPTION_ID = "<SubscriptionId>"
     ```
 
+4. Enable ACI in your subscription:
+
+   ```cli
+   az provider register -n Microsoft.ContainerInstance
+   ```
+
 ## Quick set-up with the ACI Connector
 
 The Azure cli can be used to install the ACI provider. We like to say Azure's provider or implementation for Virtual Kubelet is the ACI Connector. 
@@ -181,14 +187,6 @@ resources on your account on behalf of Kubernetes.
     $env:AZURE_CLIENT_ID = "<AppId>"
     $env:AZURE_CLIENT_SECRET = "<Password>"
     ```
-
-### Setting up your Azure account to use ACI
-
-You will need to enable ACI in your subscription:
-
-```cli
-az provider register -n Microsoft.ContainerInstance
-```
 
 ## Deployment of the ACI provider in your cluster
 


### PR DESCRIPTION
Regardless of whether you use the quick-start or the manual setup,
you need to run:
`az provider register --namespace 'Microsoft.ContainerInstance'`
on your account. Move up from the 'Manual' section.