### PR TITLE
Bug fixes

### DIFF
--- a/vkubelet/vkubelet.go
+++ b/vkubelet/vkubelet.go
@@ -183,7 +183,7 @@ func (s *Server) registerNode(ctx context.Context) error {
 			NodeInfo: corev1.NodeSystemInfo{
 				OperatingSystem: s.provider.OperatingSystem(),
 				Architecture:    "amd64",
-				KubeletVersion:  "v1.8.3",
+				KubeletVersion:  "v1.11.2",
 			},
 			Capacity:        s.provider.Capacity(),
 			Allocatable:     s.provider.Capacity(),


### PR DESCRIPTION
1. Update the VK node version to 1.11.2
2. Error out when subnet doesn't exist and ACI_SUBNET_CIDR is not specified.
3. No error when subnet exist and ACI_SUBNET_CIDR is not specified.