### PR TITLE
Pass go build tags from environment.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,28 +4,23 @@ ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 
 RUN	apk add --no-cache \
-	ca-certificates
-
-COPY . /go/src/github.com/virtual-kubelet/virtual-kubelet
-
-RUN set -x \
-	&& apk add --no-cache --virtual .build-deps \
+	ca-certificates \
+	--virtual .build-deps \
 		git \
 		gcc \
 		libc-dev \
 		libgcc \
-        make \
-	&& cd /go/src/github.com/virtual-kubelet/virtual-kubelet \
-	&& make build \ 
-	&& apk del .build-deps \
-    && cp bin/virtual-kubelet /usr/bin/virtual-kubelet \
-	&& rm -rf /go \
-	&& echo "Build complete."
+        make
+
+COPY . /go/src/github.com/virtual-kubelet/virtual-kubelet
+WORKDIR /go/src/github.com/virtual-kubelet/virtual-kubelet
+ARG BUILD_TAGS="netgo osusergo"
+RUN make VK_BUILD_TAGS="${BUILD_TAGS}" build
+RUN cp bin/virtual-kubelet /usr/bin/virtual-kubelet
+
 
 FROM scratch
-
 COPY --from=builder /usr/bin/virtual-kubelet /usr/bin/virtual-kubelet
 COPY --from=builder /etc/ssl/certs/ /etc/ssl/certs
-
 ENTRYPOINT [ "/usr/bin/virtual-kubelet" ]
 CMD [ "--help" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ FROM golang:alpine as builder
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 
-RUN	apk add --no-cache \
+RUN apk add --no-cache \
 	ca-certificates \
 	--virtual .build-deps \
-		git \
-		gcc \
-		libc-dev \
-		libgcc \
+	git \
+	gcc \
+	libc-dev \
+	libgcc \
         make
 
 COPY . /go/src/github.com/virtual-kubelet/virtual-kubelet

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ all: test build
 # safebuild builds inside a docker container with no clingons from your $GOPATH
 safebuild:
 	@echo "Building..."
-	$Q docker build --build-arg BUILD_TAGS=$(tags) -t $(DOCKER_IMAGE):$(VERSION) .
+	$Q docker build --build-arg BUILD_TAGS=$(build_tags) -t $(DOCKER_IMAGE):$(VERSION) .
 
 .PHONY: build
 build: authors

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ DOCKER_IMAGE := virtual-kubelet
 exec := $(DOCKER_IMAGE)
 github_repo := virtual-kubelet/virtual-kubelet
 binary := virtual-kubelet
+build_tags := "netgo osusergo $(VK_BUILD_TAGS)"
 
 # comment this line out for quieter things
 #V := 1 # When V is set, print commands and build progress.
@@ -17,12 +18,12 @@ all: test build
 # safebuild builds inside a docker container with no clingons from your $GOPATH
 safebuild:
 	@echo "Building..."
-	$Q docker build -t $(DOCKER_IMAGE):$(VERSION) .
+	$Q docker build --build-arg BUILD_TAGS=$(tags) -t $(DOCKER_IMAGE):$(VERSION) .
 
 .PHONY: build
 build: authors
 	@echo "Building..."
-	$Q CGO_ENABLED=0 go build -a -tags netgo -ldflags '-extldflags "-static"' -o bin/$(binary) $(if $V,-v) $(VERSION_FLAGS) $(IMPORT_PATH)
+	$Q CGO_ENABLED=0 go build -a --tags $(build_tags) -ldflags '-extldflags "-static"' -o bin/$(binary) $(if $V,-v) $(VERSION_FLAGS) $(IMPORT_PATH)
 
 .PHONY: tags
 tags:
@@ -52,7 +53,7 @@ deps: setup
 
 docker:
 	@echo "Docker Build..."
-	$Q docker build -t $(DOCKER_IMAGE) .
+	$Q docker build --build-arg BUILD_TAGS="$(VK_BUILD_TAGS)" -t $(DOCKER_IMAGE) .
 
 clean:
 	@echo "Clean..."


### PR DESCRIPTION
Can now do something like `make VK_BUILD_TAGS=no_jaeger_exporter build`
and jaeger support will not be compiled in.

Currently there are build tags to omit each provider and tracing exporter.