### PR TITLE
[VK] Change the default taint effect to NoSchedule

### DIFF
--- a/cmd/taint.go
+++ b/cmd/taint.go
@@ -11,7 +11,7 @@ import (
 
 // Default taint values
 const (
-	DefaultTaintEffect = corev1.TaintEffectPreferNoSchedule
+	DefaultTaintEffect = corev1.TaintEffectNoSchedule
 	DefaultTaintKey    = "virtual-kubelet.io/provider"
 )
 


### PR DESCRIPTION
Regression bug which causes daemonset pods assign to virtual kubelet node. 
Change the default taint effect to NoSchedule.