### PR TITLE
[ACI] A few bug fix for the Network Setup

### DIFF
--- a/providers/azure/aci.go
+++ b/providers/azure/aci.go
@@ -351,10 +351,6 @@ func (p *ACIProvider) setupNetworkProfile(auth *client.Authentication) error {
 				return fmt.Errorf("unable to delegate subnet '%s' to Azure Container Instance as it is used by other Azure resource: '%v'.", p.subnetName, l)
 			}
 		} else {
-			if subnet.SubnetPropertiesFormat.IPConfigurationProfiles != nil && len(*subnet.SubnetPropertiesFormat.IPConfigurationProfiles) != 0 {
-				return fmt.Errorf("unable to delegate subnet '%s' to Azure Container Instance as its IP configuration profiles is not empty.", p.subnetName)
-			}
-
 			for _, d := range *subnet.SubnetPropertiesFormat.Delegations {
 				if d.ServiceDelegationPropertiesFormat != nil && *d.ServiceDelegationPropertiesFormat.ServiceName == subnetDelegationService {
 					createSubnet = false


### PR DESCRIPTION
1. Remove the IPConfigurationProfiles check in the subnet to delegate to ACI
2. Make the network profile name a hash of the subnet ID instead of the virtual node name to avoid conflict.