### PR TITLE
[ACI] Support to add extra user agent to the request

### DIFF
--- a/providers/azure/aci.go
+++ b/providers/azure/aci.go
@@ -196,7 +196,7 @@ func NewACIProvider(config string, rm *manager.ResourceManager, nodeName, operat
 		azAuth.SubscriptionID = subscriptionID
 	}
 
-	p.aciClient, err = aci.NewClient(azAuth)
+	p.aciClient, err = aci.NewClient(azAuth, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/azure/aci.go
+++ b/providers/azure/aci.go
@@ -75,6 +75,7 @@ type ACIProvider struct {
 	networkProfile     string
 	kubeProxyExtension *aci.Extension
 	kubeDNSIP          string
+	extraUserAgent     string
 
 	metricsSync     sync.Mutex
 	metricsSyncTime time.Time
@@ -196,7 +197,9 @@ func NewACIProvider(config string, rm *manager.ResourceManager, nodeName, operat
 		azAuth.SubscriptionID = subscriptionID
 	}
 
-	p.aciClient, err = aci.NewClient(azAuth, nil)
+	p.extraUserAgent = os.Getenv("ACI_EXTRA_USER_AGENT")
+
+	p.aciClient, err = aci.NewClient(azAuth, p.extraUserAgent)
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +318,7 @@ func NewACIProvider(config string, rm *manager.ResourceManager, nodeName, operat
 }
 
 func (p *ACIProvider) setupNetworkProfile(auth *client.Authentication) error {
-	c, err := network.NewClient(auth)
+	c, err := network.NewClient(auth, p.extraUserAgent)
 	if err != nil {
 		return fmt.Errorf("error creating azure networking client: %v", err)
 	}

--- a/providers/azure/client/aci/client.go
+++ b/providers/azure/client/aci/client.go
@@ -13,9 +13,9 @@ import (
 
 const (
 	// BaseURI is the default URI used for compute services.
-	baseURI    = "https://management.azure.com"
-	userAgent  = "virtual-kubelet/azure-arm-aci/2018-09-01"
-	apiVersion = "2018-09-01"
+	baseURI          = "https://management.azure.com"
+	defaultUserAgent = "virtual-kubelet/azure-arm-aci/2018-09-01"
+	apiVersion       = "2018-09-01"
 
 	containerGroupURLPath                    = "subscriptions/{{.subscriptionId}}/resourceGroups/{{.resourceGroup}}/providers/Microsoft.ContainerInstance/containerGroups/{{.containerGroupName}}"
 	containerGroupListURLPath                = "subscriptions/{{.subscriptionId}}/providers/Microsoft.ContainerInstance/containerGroups"
@@ -35,10 +35,12 @@ type Client struct {
 }
 
 // NewClient creates a new Azure Container Instances client.
-func NewClient(auth *azure.Authentication) (*Client, error) {
+func NewClient(auth *azure.Authentication, userAgent []string) (*Client, error) {
 	if auth == nil {
 		return nil, fmt.Errorf("Authentication is not supplied for the Azure client")
 	}
+
+	userAgent = append(userAgent, defaultUserAgent)
 
 	client, err := azure.NewClient(auth, baseURI, userAgent)
 	if err != nil {

--- a/providers/azure/client/aci/client.go
+++ b/providers/azure/client/aci/client.go
@@ -34,15 +34,13 @@ type Client struct {
 	auth *azure.Authentication
 }
 
-// NewClient creates a new Azure Container Instances client.
-func NewClient(auth *azure.Authentication, userAgent []string) (*Client, error) {
+// NewClient creates a new Azure Container Instances client with extra user agent.
+func NewClient(auth *azure.Authentication, extraUserAgent string) (*Client, error) {
 	if auth == nil {
 		return nil, fmt.Errorf("Authentication is not supplied for the Azure client")
 	}
 
-	userAgent = append(userAgent, defaultUserAgent)
-
-	client, err := azure.NewClient(auth, baseURI, userAgent)
+	client, err := azure.NewClient(auth, baseURI, []string{defaultUserAgent, extraUserAgent})
 	if err != nil {
 		return nil, fmt.Errorf("Creating Azure client failed: %v", err)
 	}

--- a/providers/azure/client/aci/client.go
+++ b/providers/azure/client/aci/client.go
@@ -40,7 +40,12 @@ func NewClient(auth *azure.Authentication, extraUserAgent string) (*Client, erro
 		return nil, fmt.Errorf("Authentication is not supplied for the Azure client")
 	}
 
-	client, err := azure.NewClient(auth, baseURI, []string{defaultUserAgent, extraUserAgent})
+	userAgent := []string{defaultUserAgent}
+	if extraUserAgent != "" {
+		userAgent = append(userAgent, extraUserAgent)
+	}
+
+	client, err := azure.NewClient(auth, baseURI, userAgent)
 	if err != nil {
 		return nil, fmt.Errorf("Creating Azure client failed: %v", err)
 	}

--- a/providers/azure/client/aci/client_test.go
+++ b/providers/azure/client/aci/client_test.go
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 	subscriptionID = auth.SubscriptionID
 
 	// Check if the resource group exists and create it if not.
-	rgCli, err := resourcegroups.NewClient(auth)
+	rgCli, err := resourcegroups.NewClient(auth, []string{})
 	if err != nil {
 		log.Fatalf("creating new resourcegroups client failed: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestNewClient(t *testing.T) {
 		log.Fatalf("Failed to load Azure authentication file: %v", err)
 	}
 
-	c, err := NewClient(auth)
+	c, err := NewClient(auth, []string{"unit-test"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/azure/client/aci/client_test.go
+++ b/providers/azure/client/aci/client_test.go
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 	subscriptionID = auth.SubscriptionID
 
 	// Check if the resource group exists and create it if not.
-	rgCli, err := resourcegroups.NewClient(auth, []string{})
+	rgCli, err := resourcegroups.NewClient(auth, "unit-test")
 	if err != nil {
 		log.Fatalf("creating new resourcegroups client failed: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestNewClient(t *testing.T) {
 		log.Fatalf("Failed to load Azure authentication file: %v", err)
 	}
 
-	c, err := NewClient(auth, []string{"unit-test"})
+	c, err := NewClient(auth, "unit-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/azure/client/client.go
+++ b/providers/azure/client/client.go
@@ -52,9 +52,16 @@ func NewClient(auth *Authentication, baseURI string, userAgent []string) (*Clien
 
 	client.BearerAuthorizer = &BearerAuthorizer{tokenProvider: tp}
 
+	nonEmptyUserAgent := userAgent[:0]
+	for _, ua := range userAgent {
+		if ua != "" {
+			nonEmptyUserAgent = append(nonEmptyUserAgent, ua)
+		}
+	}
+
 	uat := userAgentTransport{
 		base:      http.DefaultTransport,
-		userAgent: userAgent,
+		userAgent: nonEmptyUserAgent,
 		client:    client,
 	}
 

--- a/providers/azure/client/client.go
+++ b/providers/azure/client/client.go
@@ -77,7 +77,7 @@ func (t userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error)
 	}
 
 	// Add the user agent header.
-	newReq.Header["User-Agent"] = t.userAgent
+	newReq.Header["User-Agent"] = []string{strings.Join(t.userAgent, " ")}
 
 	// Add the content-type header.
 	newReq.Header["Content-Type"] = []string{"application/json"}

--- a/providers/azure/client/client.go
+++ b/providers/azure/client/client.go
@@ -24,13 +24,13 @@ type BearerAuthorizer struct {
 }
 
 type userAgentTransport struct {
-	userAgent string
+	userAgent []string
 	base      http.RoundTripper
 	client    *Client
 }
 
 // NewClient creates a new Azure API client from an Authentication struct and BaseURI.
-func NewClient(auth *Authentication, baseURI string, userAgent string) (*Client, error) {
+func NewClient(auth *Authentication, baseURI string, userAgent []string) (*Client, error) {
 	resource, err := getResourceForToken(auth, baseURI)
 	if err != nil {
 		return nil, fmt.Errorf("Getting resource for token failed: %v", err)
@@ -77,7 +77,7 @@ func (t userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error)
 	}
 
 	// Add the user agent header.
-	newReq.Header["User-Agent"] = []string{t.userAgent}
+	newReq.Header["User-Agent"] = t.userAgent
 
 	// Add the content-type header.
 	newReq.Header["Content-Type"] = []string{"application/json"}

--- a/providers/azure/client/network/client.go
+++ b/providers/azure/client/network/client.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	baseURI    = "https://management.azure.com"
-	userAgent  = "virtual-kubelet/azure-arm-networking/2018-07-01"
-	apiVersion = "2018-07-01"
+	baseURI          = "https://management.azure.com"
+	defaultUserAgent = "virtual-kubelet/azure-arm-network/2018-08-01"
+	apiVersion       = "2018-08-01"
 )
 
 // Client is a client for interacting with Azure networking
@@ -25,10 +25,12 @@ type Client struct {
 }
 
 // NewClient creates a new client for interacting with azure networking
-func NewClient(azAuth *azure.Authentication) (*Client, error) {
+func NewClient(azAuth *azure.Authentication, userAgent []string) (*Client, error) {
 	if azAuth == nil {
 		return nil, fmt.Errorf("Authentication is not supplied for the Azure client")
 	}
+
+	userAgent = append(userAgent, defaultUserAgent)
 
 	client, err := azure.NewClient(azAuth, baseURI, userAgent)
 	if err != nil {

--- a/providers/azure/client/network/client.go
+++ b/providers/azure/client/network/client.go
@@ -25,14 +25,12 @@ type Client struct {
 }
 
 // NewClient creates a new client for interacting with azure networking
-func NewClient(azAuth *azure.Authentication, userAgent []string) (*Client, error) {
+func NewClient(azAuth *azure.Authentication, extraUserAgent string) (*Client, error) {
 	if azAuth == nil {
 		return nil, fmt.Errorf("Authentication is not supplied for the Azure client")
 	}
 
-	userAgent = append(userAgent, defaultUserAgent)
-
-	client, err := azure.NewClient(azAuth, baseURI, userAgent)
+	client, err := azure.NewClient(azAuth, baseURI, []string{defaultUserAgent, extraUserAgent})
 	if err != nil {
 		return nil, fmt.Errorf("Creating Azure client failed: %v", err)
 	}

--- a/providers/azure/client/network/client.go
+++ b/providers/azure/client/network/client.go
@@ -30,7 +30,12 @@ func NewClient(azAuth *azure.Authentication, extraUserAgent string) (*Client, er
 		return nil, fmt.Errorf("Authentication is not supplied for the Azure client")
 	}
 
-	client, err := azure.NewClient(azAuth, baseURI, []string{defaultUserAgent, extraUserAgent})
+	userAgent := []string{defaultUserAgent}
+	if extraUserAgent != "" {
+		userAgent = append(userAgent, extraUserAgent)
+	}
+
+	client, err := azure.NewClient(azAuth, baseURI, userAgent)
 	if err != nil {
 		return nil, fmt.Errorf("Creating Azure client failed: %v", err)
 	}

--- a/providers/azure/client/network/main_test.go
+++ b/providers/azure/client/network/main_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	c, err := resourcegroups.NewClient(testAuth, []string{})
+	c, err := resourcegroups.NewClient(testAuth, "unit-test")
 	if err != nil {
 		os.Exit(1)
 	}
@@ -68,7 +68,7 @@ func newTestClient(t *testing.T) *Client {
 	if err := setupAuth(); err != nil {
 		t.Fatal(err)
 	}
-	c, err := NewClient(testAuth, []string{})
+	c, err := NewClient(testAuth, "unit-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/azure/client/network/main_test.go
+++ b/providers/azure/client/network/main_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	c, err := resourcegroups.NewClient(testAuth)
+	c, err := resourcegroups.NewClient(testAuth, []string{})
 	if err != nil {
 		os.Exit(1)
 	}
@@ -68,7 +68,7 @@ func newTestClient(t *testing.T) *Client {
 	if err := setupAuth(); err != nil {
 		t.Fatal(err)
 	}
-	c, err := NewClient(testAuth)
+	c, err := NewClient(testAuth, []string{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/azure/client/resourcegroups/client.go
+++ b/providers/azure/client/resourcegroups/client.go
@@ -9,9 +9,9 @@ import (
 
 const (
 	// BaseURI is the default URI used for compute services.
-	BaseURI    = "https://management.azure.com"
-	userAgent  = "virtual-kubelet/azure-arm-resourcegroups/2017-12-01"
-	apiVersion = "2017-08-01"
+	BaseURI          = "https://management.azure.com"
+	defaultUserAgent = "virtual-kubelet/azure-arm-resourcegroups/2017-12-01"
+	apiVersion       = "2017-08-01"
 
 	resourceGroupURLPath = "subscriptions/{{.subscriptionId}}/resourcegroups/{{.resourceGroupName}}"
 )
@@ -26,11 +26,13 @@ type Client struct {
 }
 
 // NewClient creates a new Azure resource groups client.
-func NewClient(auth *azure.Authentication) (*Client, error) {
+func NewClient(auth *azure.Authentication, userAgent []string) (*Client, error) {
 	if auth == nil {
 		return nil, fmt.Errorf("Authentication is not supplied for the Azure client")
 	}
 
+	userAgent = append(userAgent, defaultUserAgent)
+	
 	client, err := azure.NewClient(auth, BaseURI, userAgent)
 	if err != nil {
 		return nil, fmt.Errorf("Creating Azure client failed: %v", err)

--- a/providers/azure/client/resourcegroups/client.go
+++ b/providers/azure/client/resourcegroups/client.go
@@ -31,7 +31,12 @@ func NewClient(auth *azure.Authentication, extraUserAgent string) (*Client, erro
 		return nil, fmt.Errorf("Authentication is not supplied for the Azure client")
 	}
 
-	client, err := azure.NewClient(auth, BaseURI, []string{defaultUserAgent, extraUserAgent})
+	userAgent := []string{defaultUserAgent}
+	if extraUserAgent != "" {
+		userAgent = append(userAgent, extraUserAgent)
+	}
+
+	client, err := azure.NewClient(auth, BaseURI, userAgent)
 	if err != nil {
 		return nil, fmt.Errorf("Creating Azure client failed: %v", err)
 	}

--- a/providers/azure/client/resourcegroups/client.go
+++ b/providers/azure/client/resourcegroups/client.go
@@ -26,14 +26,12 @@ type Client struct {
 }
 
 // NewClient creates a new Azure resource groups client.
-func NewClient(auth *azure.Authentication, userAgent []string) (*Client, error) {
+func NewClient(auth *azure.Authentication, extraUserAgent string) (*Client, error) {
 	if auth == nil {
 		return nil, fmt.Errorf("Authentication is not supplied for the Azure client")
 	}
 
-	userAgent = append(userAgent, defaultUserAgent)
-	
-	client, err := azure.NewClient(auth, BaseURI, userAgent)
+	client, err := azure.NewClient(auth, BaseURI, []string{defaultUserAgent, extraUserAgent})
 	if err != nil {
 		return nil, fmt.Errorf("Creating Azure client failed: %v", err)
 	}

--- a/providers/azure/client/resourcegroups/client_test.go
+++ b/providers/azure/client/resourcegroups/client_test.go
@@ -25,7 +25,7 @@ func TestNewClient(t *testing.T) {
 		t.Fatalf("Failed to load Azure authentication file: %v", err)
 	}
 
-	c, err := NewClient(auth)
+	c, err := NewClient(auth, []string{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/azure/client/resourcegroups/client_test.go
+++ b/providers/azure/client/resourcegroups/client_test.go
@@ -25,7 +25,7 @@ func TestNewClient(t *testing.T) {
 		t.Fatalf("Failed to load Azure authentication file: %v", err)
 	}
 
-	c, err := NewClient(auth, []string{})
+	c, err := NewClient(auth, "unit-test")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
User can set the extra user agent in the ACI_EXTRA_USER_AGENT environment.
If more than one extra user agent, use whitespace to separate them.