### PR TITLE
Add AWS/Fargate configuration options to chart.

### DIFF
--- a/charts/virtual-kubelet/templates/_helpers.tpl
+++ b/charts/virtual-kubelet/templates/_helpers.tpl
@@ -27,3 +27,10 @@ labels:
   chartVersion: "{{ .Chart.Version }}"
   app: {{ template "vk.name" . }}
 {{- end -}}
+
+{{- define "vk.list_to_toml" -}}
+{{- $local := dict "first" true -}}
+{{- print "[" -}}
+{{- range $k, $v := . -}}{{- if not $local.first -}},{{- end -}}{{- $v | quote -}}{{- $_ := set $local "first" false -}}{{- end -}}
+{{- print "]" -}}
+{{- end -}}

--- a/charts/virtual-kubelet/templates/configmap.yaml
+++ b/charts/virtual-kubelet/templates/configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "vk.fullname" . }}
+{{ include "vk.labels" . | indent 2 }}
+data:
+  {{- if eq .Values.provider "aws" }}
+  {{- with .Values.providers.aws }}
+  {{- if .targetFargate }}
+  aws_fargate_toml: |
+    Region = "{{ .region }}"
+    ClusterName = "{{ .clusterName }}"
+    Subnets = {{ template "vk.list_to_toml" .subnets }}
+    {{- if .securityGroups }}
+    SecurityGroups = {{ template "vk.list_to_toml" .securityGroups }}
+    {{- end }}
+    AssignPublicIPv4Address = {{ .assignPublicIPv4Address }}
+    ExecutionRoleArn = "{{ .executionRoleARN }}"
+    CloudWatchLogGroupName = "{{ .cloudWatchLogGroupName }}"
+    PlatformVersion = "{{ .platformVersion }}"
+    OperatingSystem = "{{ tpl .operatingSystem $ }}"
+    CPU = {{ .limits.cpu | quote }}
+    Memory = "{{ .limits.memory }}"
+    Pods = {{ .limits.pods | quote }}
+  {{- end }}
+  {{- end }}
+  {{- end }}

--- a/charts/virtual-kubelet/templates/deployment.yaml
+++ b/charts/virtual-kubelet/templates/deployment.yaml
@@ -98,12 +98,23 @@ spec:
           mountPath: "/etc/acs/azure.json"
 {{- end }}
 {{- end }}
+{{- if eq .Values.provider "aws" }}
+{{- if .Values.providers.aws.targetFargate }}
+        - name: fargate-config
+          mountPath: "/etc/aws"
+{{- end }}
+{{- end }}
         command: ["virtual-kubelet"]
         args: [
 {{- if not .Values.taint.enabled }}
           "--disable-taint", "true",
 {{- end }}
           "--provider", "{{ required "provider is required" .Values.provider }}",
+          {{- if eq .Values.provider "aws" }}
+          {{- if .Values.providers.aws.targetFargate }}
+          "--provider-config", "/etc/aws/fargate.toml",
+          {{- end }}
+          {{- end }}
           "--namespace", "{{ .Values.monitoredNamespace }}",
           "--nodename", "{{ required "nodeName is required" .Values.nodeName }}",
           {{- if .Values.logLevel }}
@@ -121,6 +132,16 @@ spec:
         hostPath:
           path: /etc/kubernetes/azure.json
           type: File
+{{- end }}
+{{- end }}
+{{- if eq .Values.provider "aws" }}
+{{- if .Values.providers.aws.targetFargate }}
+      - name: fargate-config
+        configMap:
+          name: {{ template "vk.fullname" . }}
+          items:
+          - key: aws_fargate_toml
+            path: fargate.toml
 {{- end }}
 {{- end }}
       serviceAccountName: {{ if .Values.rbac.install }} "{{ template "vk.fullname" . }}" {{ end }}

--- a/charts/virtual-kubelet/values.yaml
+++ b/charts/virtual-kubelet/values.yaml
@@ -4,7 +4,7 @@ image:
   pullPolicy: Always
 
 ## `provider` should be one of aws, azure, azurebatch, etc...
-provider: 
+provider: ""
 nodeName: "virtual-kubelet"
 nodeOsType: "Linux"
 monitoredNamespace: ""
@@ -42,7 +42,24 @@ providers:
       subnetCidr: 
       clusterCidr: 
       kubeDnsIp: 
-
+  aws:
+    targetFargate: true
+    region: us-east-1
+    clusterName: my-cluster
+    subnets:
+    - subnet-0123456789abcdef12
+    - subnet-0123456789abcdef13
+    - subnet-0123456789abcdef14
+    securityGroups: []
+    assignPublicIPv4Address: false
+    executionRoleARN: ""
+    cloudWatchLogGroupName: ""
+    platformVersion: "LATEST"
+    operatingSystem: "{{ .Values.nodeOsType }}"
+    limits:
+      cpu: 20
+      memory: "40Gi"
+      pods: 20
 ## Install Default RBAC roles and bindings
 rbac:
   install: true


### PR DESCRIPTION
While playing around with virtual-kubelet in my AWS environment, I noticed, that the helm chart lacks the necessary configuration options to enable AWS/Fargate support. This PR should add everything that is needed to create the requried .toml configuration file by using a ConfigMap.