### PR TITLE
Fix pod deletion

### DIFF
--- a/hack/skaffold/virtual-kubelet/base.yml
+++ b/hack/skaffold/virtual-kubelet/base.yml
@@ -12,9 +12,18 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
   - secrets
   verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
   - list
   - watch
 - apiGroups:
@@ -29,7 +38,6 @@ rules:
   resources:
   - nodes/status
   verbs:
-  - get
   - update
 - apiGroups:
   - ""

--- a/vkubelet/pod.go
+++ b/vkubelet/pod.go
@@ -214,7 +214,7 @@ func (s *Server) deletePod(ctx context.Context, pod *corev1.Pod) error {
 	logger := log.G(ctx).WithField("pod", pod.GetName()).WithField("namespace", pod.GetNamespace())
 	if !errors.IsNotFound(delErr) {
 		var grace int64
-		if err := s.k8sClient.CoreV1().Pods(pod.GetNamespace()).Delete(pod.GetName(), &metav1.DeleteOptions{GracePeriodSeconds: &grace}); err != nil && errors.IsNotFound(err) {
+		if err := s.k8sClient.CoreV1().Pods(pod.GetNamespace()).Delete(pod.GetName(), &metav1.DeleteOptions{GracePeriodSeconds: &grace}); err != nil {
 			if errors.IsNotFound(err) {
 				span.Annotate(nil, "Pod does not exist in k8s, nothing to delete")
 				return nil


### PR DESCRIPTION
The introduction of `skaffold` - and ultimately the unfortunate fact that a permission was missing from the virtual-kubelet cluster role binding - allowed to uncover a bug in `pod.go`: when trying to delete a Pod resource from the Kubernetes API, any errors except for 404 would be swallowed (i.e. not propagated, and no log messages would be printed).