### PR TITLE
ci: move go vet to validate check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: go vet
+          command: V=1 CI=1 make vet
+      - run:
           name: Install linters
           command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s v1.10.2 && mv ./bin/* /go/bin/
       - run:

--- a/Makefile
+++ b/Makefile
@@ -60,19 +60,27 @@ clean:
 	@echo "Clean..."
 	$Q rm -rf bin
 
+vet:
+	@echo "go vet'ing..."
+ifndef CI
+	@echo "go vet'ing Outside CI..."
+	$Q go vet $(allpackages)
+else
+	@echo "go vet'ing in CI..."
+	$Q mkdir -p test
+	$Q ( go vet $(allpackages); echo $$? ) | \
+       tee test/vet.txt | sed '$$ d'; exit $$(tail -1 test/vet.txt)
+endif
 
 test:
 	@echo "Testing..."
 	$Q go test $(if $V,-v) -i $(allpackages) # install -race libs to speed up next run
 ifndef CI
 	@echo "Testing Outside CI..."
-	$Q go vet $(allpackages)
 	$Q GODEBUG=cgocheck=2 go test $(allpackages)
 else
 	@echo "Testing in CI..."
 	$Q mkdir -p test
-	$Q ( go vet $(allpackages); echo $$? ) | \
-       tee test/vet.txt | sed '$$ d'; exit $$(tail -1 test/vet.txt)
 	$Q ( GODEBUG=cgocheck=2 go test -v $(allpackages); echo $$? ) | \
        tee test/output.txt | sed '$$ d'; exit $$(tail -1 test/output.txt)
 endif

--- a/providers/cri/cri.go
+++ b/providers/cri/cri.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package cri
 
 import (


### PR DESCRIPTION
I also took the liberty to tag the CRI provider to only build when on Linux. This way, `make vet` on my MacOS doesn't complain about it.