### PR TITLE
mock: do not panic on unknown pods

### DIFF
--- a/providers/mock/mock.go
+++ b/providers/mock/mock.go
@@ -190,8 +190,7 @@ func (p *MockProvider) GetPod(ctx context.Context, namespace, name string) (pod 
 	if pod, ok := p.pods[key]; ok {
 		return pod, nil
 	}
-
-	return nil, nil
+	return nil, strongerrors.NotFound(fmt.Errorf("pod \"%s/%s\" is not known to the provider", namespace, name))
 }
 
 // GetContainerLogs retrieves the logs of a container by name from the provider.
@@ -255,7 +254,7 @@ func (p *MockProvider) GetPodStatus(ctx context.Context, namespace, name string)
 
 	pod, err := p.GetPod(ctx, namespace, name)
 	if err != nil {
-		return status, err
+		return nil, err
 	}
 
 	for _, container := range pod.Spec.Containers {


### PR DESCRIPTION
Currently, if a pod resource is created but for some reason the mock provider does not know about it (due to an invalid resource spec or some other error), a call to `GetPodStatus` will panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x138 pc=0x107a96e]

goroutine 157 [running]:
github.com/virtual-kubelet/virtual-kubelet/providers/mock.(*MockProvider).GetPodStatus(0xc00052b830, 0x16fb320, 0xc0007bdcb0, 0xc0000c1d39, 0x7, 0xc0000c1d00, 0x10, 0x0, 0x0, 0x0)
	/Users/bcustodio/Work/Go/src/github.com/virtual-kubelet/virtual-kubelet/providers/mock/mock.go:261 +0x3ce
github.com/virtual-kubelet/virtual-kubelet/vkubelet.(*Server).updatePodStatus(0xc000348000, 0x16fb320, 0xc0007bdc50, 0xc00061a700, 0x0, 0x0)
	/Users/bcustodio/Work/Go/src/github.com/virtual-kubelet/virtual-kubelet/vkubelet/pod.go:180 +0x1d9
github.com/virtual-kubelet/virtual-kubelet/vkubelet.(*Server).updatePodStatuses.func1(0xc000669200, 0xc00062e180, 0xc0002fd3e0, 0xc000084780, 0xc000348000, 0xc00061a700)
	/Users/bcustodio/Work/Go/src/github.com/virtual-kubelet/virtual-kubelet/vkubelet/pod.go:158 +0x17e
created by github.com/virtual-kubelet/virtual-kubelet/vkubelet.(*Server).updatePodStatuses
	/Users/bcustodio/Work/Go/src/github.com/virtual-kubelet/virtual-kubelet/vkubelet/pod.go:147 +0x28a
```

This is due to the fact that `GetPod` returns `nil, nil` whenever a pod is not known to the provider (instead of returning an error). Also, `GetPodStatus` should not return `status, err` when there is an error, but rather `nil, err`. Otherwise (and depending on the caller), an invalid status of `Running` may be reported.