### PR TITLE
Modify providers shortcode

### DIFF
--- a/website/data/providers.yaml
+++ b/website/data/providers.yaml
@@ -1,5 +1,5 @@
 - name: Alibaba Cloud Elastic Container Instance (**ECI**)
-  tag: alicloud
+  tag: alibabacloud
 - name: AWS Fargate
   tag: aws
 - name: Azure Batch

--- a/website/layouts/shortcodes/providers.html
+++ b/website/layouts/shortcodes/providers.html
@@ -1,15 +1,5 @@
 {{- $providers := .Site.Data.providers }}
 <table>
-  <thead>
-    <tr>
-      <th>
-        Provider
-      </th>
-      <th>
-        Go package
-      </th>
-    </tr>
-  </thead>
   <tbody>
     {{ range $providers }}
     {{ $name     := .name | markdownify }}
@@ -18,15 +8,16 @@
     {{ $godocUrl := printf "https://godoc.org/%s" $pkgName }}
     <tr>
       <td>
+        {{ $name }}
+      </td>
+      <td>
         <a href="{{ $pkgUrl }}" target="_blank">
-          {{ $name }}
+          Docs
         </a>
       </td>
       <td>
         <a href="{{ $godocUrl }}" target="_blank">
-          <code>
-            {{ $pkgName }}
-          </code>
+          GoDoc
         </a>
       </td>
     </tr>

--- a/website/layouts/shortcodes/providers.html
+++ b/website/layouts/shortcodes/providers.html
@@ -1,11 +1,35 @@
 {{- $providers := .Site.Data.providers }}
-<ul>
-  {{- range $providers }}
-  {{- $url := printf "https://github.com/virtual-kubelet/virtual-kubelet/tree/master/providers/%s" .tag }}
-  <li>
-    <a href="{{ $url }}">
-      {{ .name | markdownify }}
-    </a>
-  </li>
-  {{- end }}
-</ul>
+<table>
+  <thead>
+    <tr>
+      <th>
+        Provider
+      </th>
+      <th>
+        Go package
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    {{ range $providers }}
+    {{ $name     := .name | markdownify }}
+    {{ $pkgName  := printf "github.com/virtual-kubelet/virtual-kubelet/providers/%s" .tag }}
+    {{ $pkgUrl   := printf "https://github.com/virtual-kubelet/virtual-kubelet/tree/master/providers/%s" .tag }}
+    {{ $godocUrl := printf "https://godoc.org/%s" $pkgName }}
+    <tr>
+      <td>
+        <a href="{{ $pkgUrl }}" target="_blank">
+          {{ $name }}
+        </a>
+      </td>
+      <td>
+        <a href="{{ $godocUrl }}" target="_blank">
+          <code>
+            {{ $pkgName }}
+          </code>
+        </a>
+      </td>
+    </tr>
+    {{ end }}
+  </tbody>
+</table>


### PR DESCRIPTION
This PR updates the list of providers (see [here](https://virtual-kubelet.netlify.com/docs/providers/#current-providers)) to include a GoDoc link for each provider.

You can see a preview of the new table [here](https://deploy-preview-497--virtual-kubelet.netlify.com/docs/#providers).