### PR TITLE
Update Alibaba tag

### DIFF
--- a/website/data/providers.yaml
+++ b/website/data/providers.yaml
@@ -1,5 +1,5 @@
 - name: Alibaba Cloud Elastic Container Instance (**ECI**)
-  tag: alicloud
+  tag: alibabacloud
 - name: AWS Fargate
   tag: aws
 - name: Azure Batch


### PR DESCRIPTION
Apparently the subdirectory of the Alibaba provider has changed to `alibabacloud` from `alicloud`. This PR updates `providers.yaml` to reflect that.