### PR TITLE
Update website root URL to new .io address

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -1,6 +1,6 @@
 # Basic site config
 title           = "Virtual Kubelet"
-baseURL         = "https://virtual-kubelet.netlify.com"
+baseURL         = "https://virtual-kubelet.io"
 languageCode    = "en-us"
 enableRobotsTxt = true
 


### PR DESCRIPTION
This PR updates the Hugo config to use the new `virtual-kubelet.io` domain as the root URL. This should fix any outstanding issues with absolute URLs.