### PR TITLE
Make tracing interface to coalesce logging/tracing

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,20 +30,21 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"go.opencensus.io/trace"
+	"github.com/virtual-kubelet/virtual-kubelet/log"
+	logruslogger "github.com/virtual-kubelet/virtual-kubelet/log/logrus"
+	"github.com/virtual-kubelet/virtual-kubelet/manager"
+	"github.com/virtual-kubelet/virtual-kubelet/providers"
+	"github.com/virtual-kubelet/virtual-kubelet/providers/register"
+	"github.com/virtual-kubelet/virtual-kubelet/trace"
+	"github.com/virtual-kubelet/virtual-kubelet/trace/opencensus"
+	"github.com/virtual-kubelet/virtual-kubelet/vkubelet"
+	octrace "go.opencensus.io/trace"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	kubeinformers "k8s.io/client-go/informers"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/virtual-kubelet/virtual-kubelet/log"
-	logruslogger "github.com/virtual-kubelet/virtual-kubelet/log/logrus"
-	"github.com/virtual-kubelet/virtual-kubelet/manager"
-	"github.com/virtual-kubelet/virtual-kubelet/providers"
-	"github.com/virtual-kubelet/virtual-kubelet/providers/register"
-	"github.com/virtual-kubelet/virtual-kubelet/vkubelet"
 )
 
 const (
@@ -162,8 +163,9 @@ func (mv mapVar) Type() string {
 }
 
 func init() {
-	// make sure the default logger is initialized
+	// make sure the default logger/tracer is initialized
 	log.L = logruslogger.FromLogrus(logrus.NewEntry(logrus.StandardLogger()))
+	trace.T = opencensus.Adapter{}
 
 	cobra.OnInitialize(initConfig)
 
@@ -345,16 +347,16 @@ func initConfig() {
 		if err != nil {
 			log.L.WithError(err).WithField("exporter", e).Fatal("Cannot initialize exporter")
 		}
-		trace.RegisterExporter(exporter)
+		octrace.RegisterExporter(exporter)
 	}
 	if len(userTraceExporters) > 0 {
-		var s trace.Sampler
+		var s octrace.Sampler
 		switch strings.ToLower(traceSampler) {
 		case "":
 		case "always":
-			s = trace.AlwaysSample()
+			s = octrace.AlwaysSample()
 		case "never":
-			s = trace.NeverSample()
+			s = octrace.NeverSample()
 		default:
 			rate, err := strconv.Atoi(traceSampler)
 			if err != nil {
@@ -363,12 +365,12 @@ func initConfig() {
 			if rate < 0 || rate > 100 {
 				logger.WithField("rate", traceSampler).Fatal("trace sample rate must not be less than zero or greater than 100")
 			}
-			s = trace.ProbabilitySampler(float64(rate) / 100)
+			s = octrace.ProbabilitySampler(float64(rate) / 100)
 		}
 
 		if s != nil {
-			trace.ApplyConfig(
-				trace.Config{
+			octrace.ApplyConfig(
+				octrace.Config{
 					DefaultSampler: s,
 				},
 			)

--- a/log/log.go
+++ b/log/log.go
@@ -31,7 +31,7 @@ var (
 	// L is the default logger. It should be initialized before using `G` or `GetLogger`
 	// If L is unitialized and no logger is available in a provided context, a
 	// panic will occur.
-	L Logger
+	L Logger = nopLogger{}
 )
 
 type (

--- a/log/log.go
+++ b/log/log.go
@@ -14,77 +14,71 @@
    limitations under the License.
 */
 
+// Package log defines the interfaces used for logging in virtual-kubelet.
+// It uses a context.Context to store logger details. Additionally you can set
+// the default logger to use by setting log.L. This is used when no logger is
+// stored in the passed in context.
 package log
 
 import (
 	"context"
-	"sync/atomic"
-
-	"github.com/Sirupsen/logrus"
 )
 
 var (
 	// G is an alias for GetLogger.
-	//
-	// We may want to define this locally to a package to get package tagged log
-	// messages.
 	G = GetLogger
 
-	// L is an alias for the the standard logger.
-	L = logrus.NewEntry(logrus.StandardLogger())
+	// L is the default logger. It should be initialized before using `G` or `GetLogger`
+	// If L is unitialized and no logger is available in a provided context, a
+	// panic will occur.
+	L Logger
 )
 
 type (
 	loggerKey struct{}
 )
 
-// TraceLevel is the log level for tracing. Trace level is lower than debug level,
-// and is usually used to trace detailed behavior of the program.
-const TraceLevel = logrus.Level(uint32(logrus.DebugLevel + 1))
+// Logger is the interface used for logging in virtual-kubelet
+//
+// virtual-kubelet will access the logger via context using `GetLogger` (or its alias, `G`)
+// You can set the default logger to use by setting the `L` variable.
+type Logger interface {
+	Debug(...interface{})
+	Debugf(string, ...interface{})
+	Info(...interface{})
+	Infof(string, ...interface{})
+	Warn(...interface{})
+	Warnf(string, ...interface{})
+	Error(...interface{})
+	Errorf(string, ...interface{})
+	Fatal(...interface{})
+	Fatalf(string, ...interface{})
 
-// RFC3339NanoFixed is time.RFC3339Nano with nanoseconds padded using zeros to
-// ensure the formatted time is always the same number of characters.
-const RFC3339NanoFixed = "2006-01-02T15:04:05.000000000Z07:00"
-
-// ParseLevel takes a string level and returns the Logrus log level constant.
-// It supports trace level.
-func ParseLevel(lvl string) (logrus.Level, error) {
-	if lvl == "trace" {
-		return TraceLevel, nil
-	}
-	return logrus.ParseLevel(lvl)
+	WithField(string, interface{}) Logger
+	WithFields(Fields) Logger
+	WithError(error) Logger
 }
+
+// Fields allows setting multiple fields on a logger at one time.
+type Fields map[string]interface{}
 
 // WithLogger returns a new context with the provided logger. Use in
 // combination with logger.WithField(s) for great effect.
-func WithLogger(ctx context.Context, logger *logrus.Entry) context.Context {
+func WithLogger(ctx context.Context, logger Logger) context.Context {
 	return context.WithValue(ctx, loggerKey{}, logger)
 }
 
 // GetLogger retrieves the current logger from the context. If no logger is
 // available, the default logger is returned.
-func GetLogger(ctx context.Context) *logrus.Entry {
+func GetLogger(ctx context.Context) Logger {
 	logger := ctx.Value(loggerKey{})
 
 	if logger == nil {
+		if L == nil {
+			panic("default logger not initialized")
+		}
 		return L
 	}
 
-	return logger.(*logrus.Entry)
-}
-
-// Trace logs a message at level Trace with the log entry passed-in.
-func Trace(e *logrus.Entry, args ...interface{}) {
-	level := logrus.Level(atomic.LoadUint32((*uint32)(&e.Logger.Level)))
-	if level >= TraceLevel {
-		e.Debug(args...)
-	}
-}
-
-// Tracef logs a message at level Trace with the log entry passed-in.
-func Tracef(e *logrus.Entry, format string, args ...interface{}) {
-	level := logrus.Level(atomic.LoadUint32((*uint32)(&e.Logger.Level)))
-	if level >= TraceLevel {
-		e.Debugf(format, args...)
-	}
+	return logger.(Logger)
 }

--- a/log/logrus/logrus.go
+++ b/log/logrus/logrus.go
@@ -1,0 +1,34 @@
+// Package logrus implements a github.com/virtual-kubelet/virtual-kubelet/log.Logger using Logrus as a backend
+// You can use this by creating a logrus logger and calling `FromLogrus(entry)`.
+// If you want this to be the default logger for virtual-kubelet, set `log.L` to the value returned by `FromLogrus`
+package logrus
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/virtual-kubelet/virtual-kubelet/log"
+)
+
+// Adapter implements the `log.Logger` interface for logrus
+type Adapter struct {
+	*logrus.Entry
+}
+
+// FromLogrus creates a new `log.Logger` from the provided entry
+func FromLogrus(entry *logrus.Entry) log.Logger {
+	return &Adapter{entry}
+}
+
+// WithField adds a field to the log entry.
+func (l *Adapter) WithField(key string, val interface{}) log.Logger {
+	return FromLogrus(l.Entry.WithField(key, val))
+}
+
+// WithFields adds multiple fields to a log entry.
+func (l *Adapter) WithFields(f log.Fields) log.Logger {
+	return FromLogrus(l.Entry.WithFields(logrus.Fields(f)))
+}
+
+// WithError adds an error to the log entry
+func (l *Adapter) WithError(err error) log.Logger {
+	return FromLogrus(l.Entry.WithError(err))
+}

--- a/log/logrus/logrus_test.go
+++ b/log/logrus/logrus_test.go
@@ -1,0 +1,16 @@
+package logrus
+
+import (
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/virtual-kubelet/virtual-kubelet/log"
+)
+
+func TestImplementsLoggerInterface(t *testing.T) {
+	l := FromLogrus(&logrus.Entry{})
+
+	if _, ok := l.(log.Logger); !ok {
+		t.Fatal("does not implement log.Logger interface")
+	}
+}

--- a/log/nop.go
+++ b/log/nop.go
@@ -1,0 +1,18 @@
+package log
+
+type nopLogger struct{}
+
+func (nopLogger) Debug(...interface{})          {}
+func (nopLogger) Debugf(string, ...interface{}) {}
+func (nopLogger) Info(...interface{})           {}
+func (nopLogger) Infof(string, ...interface{})  {}
+func (nopLogger) Warn(...interface{})           {}
+func (nopLogger) Warnf(string, ...interface{})  {}
+func (nopLogger) Error(...interface{})          {}
+func (nopLogger) Errorf(string, ...interface{}) {}
+func (nopLogger) Fatal(...interface{})          {}
+func (nopLogger) Fatalf(string, ...interface{}) {}
+
+func (l nopLogger) WithField(string, interface{}) Logger { return l }
+func (l nopLogger) WithFields(Fields) Logger             { return l }
+func (l nopLogger) WithError(error) Logger               { return l }

--- a/providers/azure/aci.go
+++ b/providers/azure/aci.go
@@ -25,8 +25,8 @@ import (
 	client "github.com/virtual-kubelet/virtual-kubelet/providers/azure/client"
 	"github.com/virtual-kubelet/virtual-kubelet/providers/azure/client/aci"
 	"github.com/virtual-kubelet/virtual-kubelet/providers/azure/client/network"
-	"go.opencensus.io/trace"
-	"k8s.io/api/core/v1"
+	"github.com/virtual-kubelet/virtual-kubelet/trace"
+	v1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -479,11 +479,11 @@ func getKubeProxyExtension(secretPath, masterURI, clusterCIDR string) (*aci.Exte
 	return &extension, nil
 }
 
-func addAzureAttributes(span *trace.Span, p *ACIProvider) {
-	span.AddAttributes(
-		trace.StringAttribute("azure.resourceGroup", p.resourceGroup),
-		trace.StringAttribute("azure.region", p.region),
-	)
+func addAzureAttributes(ctx context.Context, span trace.Span, p *ACIProvider) context.Context {
+	return span.WithFields(ctx, log.Fields{
+		"azure.resourceGroup": p.resourceGroup,
+		"azure.region":        p.region,
+	})
 }
 
 // CreatePod accepts a Pod definition and creates
@@ -491,7 +491,7 @@ func addAzureAttributes(span *trace.Span, p *ACIProvider) {
 func (p *ACIProvider) CreatePod(ctx context.Context, pod *v1.Pod) error {
 	ctx, span := trace.StartSpan(ctx, "aci.CreatePod")
 	defer span.End()
-	addAzureAttributes(span, p)
+	ctx = addAzureAttributes(ctx, span, p)
 
 	var containerGroup aci.ContainerGroup
 	containerGroup.Location = p.region
@@ -693,7 +693,7 @@ func (p *ACIProvider) UpdatePod(ctx context.Context, pod *v1.Pod) error {
 func (p *ACIProvider) DeletePod(ctx context.Context, pod *v1.Pod) error {
 	ctx, span := trace.StartSpan(ctx, "aci.DeletePod")
 	defer span.End()
-	addAzureAttributes(span, p)
+	ctx = addAzureAttributes(ctx, span, p)
 
 	err := p.aciClient.DeleteContainerGroup(ctx, p.resourceGroup, fmt.Sprintf("%s-%s", pod.Namespace, pod.Name))
 	return wrapError(err)
@@ -704,7 +704,7 @@ func (p *ACIProvider) DeletePod(ctx context.Context, pod *v1.Pod) error {
 func (p *ACIProvider) GetPod(ctx context.Context, namespace, name string) (*v1.Pod, error) {
 	ctx, span := trace.StartSpan(ctx, "aci.GetPod")
 	defer span.End()
-	addAzureAttributes(span, p)
+	ctx = addAzureAttributes(ctx, span, p)
 
 	cg, err, status := p.aciClient.GetContainerGroup(ctx, p.resourceGroup, fmt.Sprintf("%s-%s", namespace, name))
 	if err != nil {
@@ -725,7 +725,7 @@ func (p *ACIProvider) GetPod(ctx context.Context, namespace, name string) (*v1.P
 func (p *ACIProvider) GetContainerLogs(ctx context.Context, namespace, podName, containerName string, tail int) (string, error) {
 	ctx, span := trace.StartSpan(ctx, "aci.GetContainerLogs")
 	defer span.End()
-	addAzureAttributes(span, p)
+	ctx = addAzureAttributes(ctx, span, p)
 
 	logContent := ""
 	cg, err, _ := p.aciClient.GetContainerGroup(ctx, p.resourceGroup, fmt.Sprintf("%s-%s", namespace, podName))
@@ -743,7 +743,6 @@ func (p *ACIProvider) GetContainerLogs(ctx context.Context, namespace, podName, 
 		cLogs, err := p.aciClient.GetContainerLogs(ctx, p.resourceGroup, cg.Name, containerName, tail)
 		if err != nil {
 			log.G(ctx).WithField("method", "GetContainerLogs").WithError(err).Debug("Error getting container logs, retrying")
-			span.Annotate(nil, "Error getting container logs, retrying")
 			time.Sleep(5000 * time.Millisecond)
 		} else {
 			logContent = cLogs.Content
@@ -840,7 +839,7 @@ func (p *ACIProvider) ExecInContainer(name string, uid types.UID, container stri
 func (p *ACIProvider) GetPodStatus(ctx context.Context, namespace, name string) (*v1.PodStatus, error) {
 	ctx, span := trace.StartSpan(ctx, "aci.GetPodStatus")
 	defer span.End()
-	addAzureAttributes(span, p)
+	ctx = addAzureAttributes(ctx, span, p)
 
 	pod, err := p.GetPod(ctx, namespace, name)
 	if err != nil {
@@ -858,7 +857,7 @@ func (p *ACIProvider) GetPodStatus(ctx context.Context, namespace, name string) 
 func (p *ACIProvider) GetPods(ctx context.Context) ([]*v1.Pod, error) {
 	ctx, span := trace.StartSpan(ctx, "aci.GetPods")
 	defer span.End()
-	addAzureAttributes(span, p)
+	ctx = addAzureAttributes(ctx, span, p)
 
 	cgs, err := p.aciClient.ListContainerGroups(ctx, p.resourceGroup)
 	if err != nil {

--- a/providers/azure/aci.go
+++ b/providers/azure/aci.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/gorilla/websocket"
 	"github.com/virtual-kubelet/virtual-kubelet/log"
 	"github.com/virtual-kubelet/virtual-kubelet/manager"
@@ -875,7 +874,7 @@ func (p *ACIProvider) GetPods(ctx context.Context) ([]*v1.Pod, error) {
 
 		p, err := containerGroupToPod(&c)
 		if err != nil {
-			log.G(context.TODO()).WithFields(logrus.Fields{
+			log.G(ctx).WithFields(log.Fields{
 				"name": c.Name,
 				"id":   c.ID,
 			}).WithError(err).Error("error converting container group to pod")

--- a/providers/azure/acsCredential.go
+++ b/providers/azure/acsCredential.go
@@ -25,7 +25,7 @@ type AcsCredential struct {
 // NewAcsCredential returns an AcsCredential struct from file path
 func NewAcsCredential(p string) (*AcsCredential, error) {
 	logger := log.G(context.TODO()).WithField("method", "NewAcsCredential").WithField("file", p)
-	log.Trace(logger, "Reading ACS credential file")
+	logger.Debug("Reading ACS credential file")
 
 	b, err := ioutil.ReadFile(p)
 	if err != nil {
@@ -38,6 +38,6 @@ func NewAcsCredential(p string) (*AcsCredential, error) {
 		return nil, err
 	}
 
-	log.Trace(logger, "Load ACS credential file successfully")
+	logger.Debug("Load ACS credential file successfully")
 	return &cred, nil
 }

--- a/trace/nop.go
+++ b/trace/nop.go
@@ -1,0 +1,23 @@
+package trace
+
+import (
+	"context"
+
+	"github.com/virtual-kubelet/virtual-kubelet/log"
+	"go.opencensus.io/trace"
+)
+
+type nopTracer struct{}
+
+func (nopTracer) StartSpan(ctx context.Context, _ string) (context.Context, Span) {
+	return ctx, &nopSpan{}
+}
+
+type nopSpan struct{}
+
+func (nopSpan) End()                   {}
+func (nopSpan) SetStatus(trace.Status) {}
+func (nopSpan) Logger() log.Logger     { return nil }
+
+func (nopSpan) WithField(ctx context.Context, _ string, _ interface{}) context.Context { return ctx }
+func (nopSpan) WithFields(ctx context.Context, _ log.Fields) context.Context           { return ctx }

--- a/trace/opencensus/opencensus.go
+++ b/trace/opencensus/opencensus.go
@@ -1,0 +1,236 @@
+// Package opencensus implements a github.com/virtual-kubelet/virtual-kubelet/trace.Tracer
+// using opencensus as a backend.
+//
+// Use this by setting `trace.T = Adapter{}`
+package opencensus
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/virtual-kubelet/virtual-kubelet/log"
+	"github.com/virtual-kubelet/virtual-kubelet/trace"
+	octrace "go.opencensus.io/trace"
+)
+
+const (
+	lDebug = "DEBUG"
+	lInfo  = "INFO"
+	lWarn  = "WARN"
+	lErr   = "ERROR"
+	lFatal = "FATAL"
+)
+
+// Adapter implements the trace.Tracer interface for OpenCensus
+type Adapter struct{}
+
+// StartSpan creates a new span from opencensus using the given name.
+func (Adapter) StartSpan(ctx context.Context, name string) (context.Context, trace.Span) {
+	ctx, ocs := octrace.StartSpan(ctx, name)
+	l := log.G(ctx).WithField("method", name)
+
+	s := &span{s: ocs, l: l}
+	ctx = log.WithLogger(ctx, s.Logger())
+
+	return ctx, s
+}
+
+type span struct {
+	mu sync.Mutex
+	s  *octrace.Span
+	l  log.Logger
+}
+
+func (s *span) End() {
+	s.s.End()
+}
+
+func (s *span) SetStatus(status trace.Status) {
+	s.s.SetStatus(status)
+}
+
+func (s *span) WithField(ctx context.Context, key string, val interface{}) context.Context {
+	s.mu.Lock()
+	s.l = s.l.WithField(key, val)
+	ctx = log.WithLogger(ctx, &logger{s: s.s, l: s.l})
+	s.mu.Unlock()
+
+	if s.s.IsRecordingEvents() {
+		s.s.AddAttributes(makeAttribute(key, val))
+	}
+
+	return ctx
+}
+
+func (s *span) WithFields(ctx context.Context, f log.Fields) context.Context {
+	s.mu.Lock()
+	s.l = s.l.WithFields(f)
+	ctx = log.WithLogger(ctx, &logger{s: s.s, l: s.l})
+	s.mu.Unlock()
+
+	if s.s.IsRecordingEvents() {
+		attrs := make([]octrace.Attribute, 0, len(f))
+		for k, v := range f {
+			attrs = append(attrs, makeAttribute(k, v))
+		}
+		s.s.AddAttributes(attrs...)
+	}
+
+	return ctx
+}
+
+func (s *span) Logger() log.Logger {
+	return &logger{s: s.s, l: s.l}
+}
+
+type logger struct {
+	s *octrace.Span
+	l log.Logger
+	a []octrace.Attribute
+}
+
+func (l *logger) Debug(args ...interface{}) {
+	if !l.s.IsRecordingEvents() {
+		l.l.Debug(args...)
+		return
+	}
+
+	msg := fmt.Sprint(args...)
+	l.l.Debug(msg)
+	l.s.Annotate(withLevel(lDebug, l.a), msg)
+}
+
+func (l *logger) Debugf(f string, args ...interface{}) {
+	l.l.Debugf(f, args)
+	l.s.Annotatef(withLevel(lDebug, l.a), f, args...)
+}
+
+func (l *logger) Info(args ...interface{}) {
+	if !l.s.IsRecordingEvents() {
+		l.l.Info(args...)
+		return
+	}
+
+	msg := fmt.Sprint(args...)
+	l.l.Info(msg)
+	l.s.Annotate(withLevel(lInfo, l.a), msg)
+}
+
+func (l *logger) Infof(f string, args ...interface{}) {
+	l.l.Infof(f, args)
+	l.s.Annotatef(withLevel(lInfo, l.a), f, args...)
+}
+
+func (l *logger) Warn(args ...interface{}) {
+	if !l.s.IsRecordingEvents() {
+		l.l.Warn(args...)
+		return
+	}
+
+	msg := fmt.Sprint(args...)
+	l.l.Warn(msg)
+	l.s.Annotate(withLevel(lWarn, l.a), msg)
+}
+
+func (l *logger) Warnf(f string, args ...interface{}) {
+	l.l.Warnf(f, args)
+	l.s.Annotatef(withLevel(lWarn, l.a), f, args...)
+}
+
+func (l *logger) Error(args ...interface{}) {
+	if !l.s.IsRecordingEvents() {
+		l.l.Error(args...)
+		return
+	}
+
+	msg := fmt.Sprint(args...)
+	l.l.Error(msg)
+	l.s.Annotate(withLevel(lErr, l.a), msg)
+}
+
+func (l *logger) Errorf(f string, args ...interface{}) {
+	l.l.Errorf(f, args)
+	l.s.Annotatef(withLevel(lErr, l.a), f, args...)
+}
+
+func (l *logger) Fatal(args ...interface{}) {
+	if !l.s.IsRecordingEvents() {
+		l.l.Fatal(args...)
+		return
+	}
+
+	msg := fmt.Sprint(args...)
+	l.s.Annotate(withLevel(lFatal, l.a), msg)
+	l.l.Fatal(msg)
+}
+
+func (l *logger) Fatalf(f string, args ...interface{}) {
+	l.s.Annotatef(withLevel(lFatal, l.a), f, args...)
+	l.l.Fatalf(f, args)
+}
+
+func (l *logger) WithError(err error) log.Logger {
+	log := l.l.WithError(err)
+
+	var a []octrace.Attribute
+	if l.s.IsRecordingEvents() {
+		a = make([]octrace.Attribute, len(l.a), len(l.a)+1)
+		copy(a, l.a)
+		a = append(l.a, makeAttribute("err", err))
+	}
+
+	return &logger{s: l.s, l: log, a: a}
+}
+
+func (l *logger) WithField(k string, value interface{}) log.Logger {
+	log := l.l.WithField(k, value)
+
+	var a []octrace.Attribute
+
+	if l.s.IsRecordingEvents() {
+		a = make([]octrace.Attribute, len(l.a), len(l.a)+1)
+		copy(a, l.a)
+		a = append(a, makeAttribute(k, value))
+	}
+
+	return &logger{s: l.s, a: a, l: log}
+}
+
+func (l *logger) WithFields(fields log.Fields) log.Logger {
+	log := l.l.WithFields(fields)
+
+	var a []octrace.Attribute
+	if l.s.IsRecordingEvents() {
+		a = make([]octrace.Attribute, len(l.a), len(l.a)+len(fields))
+		copy(a, l.a)
+		for k, v := range fields {
+			a = append(a, makeAttribute(k, v))
+		}
+	}
+
+	return &logger{s: l.s, a: a, l: log}
+}
+
+func makeAttribute(key string, val interface{}) octrace.Attribute {
+	var attr octrace.Attribute
+
+	switch v := val.(type) {
+	case string:
+		attr = octrace.StringAttribute(key, v)
+	case int64:
+		attr = octrace.Int64Attribute(key, v)
+	case bool:
+		attr = octrace.BoolAttribute(key, v)
+	case error:
+		attr = octrace.StringAttribute(key, v.Error())
+	default:
+		attr = octrace.StringAttribute(key, fmt.Sprintf("%+v", val))
+	}
+
+	return attr
+}
+
+func withLevel(l string, attrs []octrace.Attribute) []octrace.Attribute {
+	return append(attrs, octrace.StringAttribute("level", l))
+}

--- a/trace/opencensus/opencensus_test.go
+++ b/trace/opencensus/opencensus_test.go
@@ -1,0 +1,13 @@
+package opencensus
+
+import (
+	"testing"
+
+	"github.com/virtual-kubelet/virtual-kubelet/trace"
+)
+
+func TestTracerImplementsTracer(t *testing.T) {
+	// ensure that Adapter implements trace.Tracer
+	if tt := trace.Tracer(Adapter{}); tt == nil {
+	}
+}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -1,0 +1,58 @@
+// Package trace abstracts virtual-kubelet's tracing capabilties into a set of
+// interfaces.
+// While this does allow consumers to use whatever tracing library they want,
+// the primary goal is to share logging data between the configured logger and
+// tracing spans instead of duplicating calls.
+package trace
+
+import (
+	"context"
+
+	"github.com/virtual-kubelet/virtual-kubelet/log"
+	"go.opencensus.io/trace"
+)
+
+// Status is an alias to opencensus's trace status.
+// The main reason we use this instead of implementing our own is library re-use,
+// namely for converting an error to a tracing status.
+// In the future this may be defined completely in this package.
+type Status = trace.Status
+
+// Tracer is the interface used for creating a tracing span
+type Tracer interface {
+	// StartSpan starts a new span. The span details are emebedded into the returned
+	// context
+	StartSpan(context.Context, string) (context.Context, Span)
+}
+
+var (
+	// T is the Tracer to use this should be initialized before starting up
+	// virtual-kubelet
+	T Tracer = nopTracer{}
+)
+
+// StartSpan starts a span from the configured default tracer
+func StartSpan(ctx context.Context, name string) (context.Context, Span) {
+	ctx, span := T.StartSpan(ctx, name)
+	ctx = log.WithLogger(ctx, span.Logger())
+	return ctx, span
+}
+
+// Span encapsulates a tracing event
+type Span interface {
+	End()
+	SetStatus(Status)
+
+	// WithField and WithFields adds attributes to an entire span
+	//
+	// This interface is a bit weird, but allows us to manage loggers in the context
+	// It is expected that implementations set `log.WithLogger` so the logger stored
+	// in the context is updated with the new fields.
+	WithField(context.Context, string, interface{}) context.Context
+	WithFields(context.Context, log.Fields) context.Context
+
+	// Logger is used to log individual entries.
+	// Calls to functions like `WithField` and `WithFields` on the logger should
+	// not affect the rest of the span but rather individual entries.
+	Logger() log.Logger
+}

--- a/vkubelet/api/helpers.go
+++ b/vkubelet/api/helpers.go
@@ -25,7 +25,7 @@ func handleError(f handlerFunc) http.HandlerFunc {
 		if code >= 500 {
 			logger.Error("Internal server error on request")
 		} else {
-			log.Trace(logger, "Error on request")
+			logger.Debug("Error on request")
 		}
 	}
 }

--- a/vkubelet/apiserver.go
+++ b/vkubelet/apiserver.go
@@ -3,7 +3,6 @@ package vkubelet
 import (
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"github.com/virtual-kubelet/virtual-kubelet/log"
 	"github.com/virtual-kubelet/virtual-kubelet/providers"
@@ -73,7 +72,7 @@ func AttachMetricsRoutes(p providers.Provider, mux ServeMux) {
 
 func instrumentRequest(r *http.Request) *http.Request {
 	ctx := r.Context()
-	logger := log.G(ctx).WithFields(logrus.Fields{
+	logger := log.G(ctx).WithFields(log.Fields{
 		"uri":  r.RequestURI,
 		"vars": mux.Vars(r),
 	})
@@ -96,14 +95,12 @@ func InstrumentHandler(h http.Handler) http.Handler {
 
 // NotFound provides a handler for cases where the requested endpoint doesn't exist
 func NotFound(w http.ResponseWriter, r *http.Request) {
-	logger := log.G(r.Context())
-	log.Trace(logger, "404 request not found")
+	log.G(r.Context()).Debug("404 request not found")
 	http.Error(w, "404 request not found", http.StatusNotFound)
 }
 
 // NotImplemented provides a handler for cases where a provider does not implement a given API
 func NotImplemented(w http.ResponseWriter, r *http.Request) {
-	logger := log.G(r.Context())
-	log.Trace(logger, "501 not implemented")
+	log.G(r.Context()).Debug("501 not implemented")
 	http.Error(w, "501 not implemented", http.StatusNotImplemented)
 }

--- a/vkubelet/node.go
+++ b/vkubelet/node.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cpuguy83/strongerrors/status/ocstatus"
 	"github.com/virtual-kubelet/virtual-kubelet/log"
+	"github.com/virtual-kubelet/virtual-kubelet/trace"
 	"github.com/virtual-kubelet/virtual-kubelet/version"
-
-	"go.opencensus.io/trace"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,12 +57,11 @@ func (s *Server) registerNode(ctx context.Context) error {
 			DaemonEndpoints: *s.provider.NodeDaemonEndpoints(ctx),
 		},
 	}
-	addNodeAttributes(span, node)
+	ctx = addNodeAttributes(ctx, span, node)
 	if _, err := s.k8sClient.CoreV1().Nodes().Create(node); err != nil && !errors.IsAlreadyExists(err) {
-		span.SetStatus(trace.Status{Code: trace.StatusCodeUnknown, Message: err.Error()})
+		span.SetStatus(ocstatus.FromError(err))
 		return err
 	}
-	span.Annotate(nil, "Registered node with k8s")
 
 	log.G(ctx).Info("Registered node")
 
@@ -77,19 +76,20 @@ func (s *Server) updateNode(ctx context.Context) {
 	opts := metav1.GetOptions{}
 	n, err := s.k8sClient.CoreV1().Nodes().Get(s.nodeName, opts)
 	if err != nil && !errors.IsNotFound(err) {
-		log.G(ctx).WithError(err).Error("Failed to retrieve node")
-		span.SetStatus(trace.Status{Code: trace.StatusCodeUnknown, Message: err.Error()})
+		log.G(ctx).WithError(err).Error("Failed to retrive node")
+		span.SetStatus(ocstatus.FromError(err))
 		return
 	}
-	addNodeAttributes(span, n)
-	span.Annotate(nil, "Fetched node details from k8s")
+
+	ctx = addNodeAttributes(ctx, span, n)
+	log.G(ctx).Debug("Fetched node details from k8s")
 
 	if errors.IsNotFound(err) {
 		if err = s.registerNode(ctx); err != nil {
 			log.G(ctx).WithError(err).Error("Failed to register node")
-			span.SetStatus(trace.Status{Code: trace.StatusCodeUnknown, Message: err.Error()})
+			span.SetStatus(ocstatus.FromError(err))
 		} else {
-			span.Annotate(nil, "Registered node in k8s")
+			log.G(ctx).Debug("Registered node in k8s")
 		}
 		return
 	}
@@ -106,7 +106,7 @@ func (s *Server) updateNode(ctx context.Context) {
 	n, err = s.k8sClient.CoreV1().Nodes().UpdateStatus(n)
 	if err != nil {
 		log.G(ctx).WithError(err).Error("Failed to update node")
-		span.SetStatus(trace.Status{Code: trace.StatusCodeUnknown, Message: err.Error()})
+		span.SetStatus(ocstatus.FromError(err))
 		return
 	}
 }
@@ -125,13 +125,11 @@ func (t taintsStringer) String() string {
 	return s
 }
 
-func addNodeAttributes(span *trace.Span, n *corev1.Node) {
-	span.AddAttributes(
-		trace.StringAttribute("UID", string(n.UID)),
-		trace.StringAttribute("name", n.Name),
-		trace.StringAttribute("cluster", n.ClusterName),
-	)
-	if span.IsRecordingEvents() {
-		span.AddAttributes(trace.StringAttribute("taints", taintsStringer(n.Spec.Taints).String()))
-	}
+func addNodeAttributes(ctx context.Context, span trace.Span, n *corev1.Node) context.Context {
+	return span.WithFields(ctx, log.Fields{
+		"UID":     string(n.UID),
+		"name":    n.Name,
+		"cluster": n.ClusterName,
+		"tains":   taintsStringer(n.Spec.Taints),
+	})
 }


### PR DESCRIPTION
Allows us to share data between the tracer and the logger so we can simplify log/trace handling where we generally want data to go both places.

Fixes #404