### PR TITLE
Add GoReleaser action

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,18 @@
+workflow "GoReleaser" {
+  on = "push"
+  resolves = ["goreleaser"]
+}
+
+action "is-tag" {
+  uses = "actions/bin/filter@master"
+  args = "tag"
+}
+
+action "goreleaser" {
+  uses = "docker://goreleaser/goreleaser"
+  secrets = [
+    "GITHUB_TOKEN"
+  ]
+  args = "release"
+  needs = ["is-tag"]
+}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ archive:
   - README*
   - changelog*
   - CHANGELOG*
-fpm:
+nfpm:
   bindir: /usr/local/bin
 snapshot:
   name_template: SNAPSHOT-{{.Commit }}


### PR DESCRIPTION
This PR adds a GitHub Action that will automatically run GoReleaser when a new tag is pushed to `master` (this will upload the VK binaries to GitHub Releases and add the Homebrew formula according to the config added in #543).

I'm also happy to add this logic via CircleCI if the maintainers would prefer using a single CI pipeline.