### PR TITLE
Add cri as possible provider in helm chart

### DIFF
--- a/charts/virtual-kubelet/templates/cniConfig.yaml
+++ b/charts/virtual-kubelet/templates/cniConfig.yaml
@@ -1,0 +1,10 @@
+{{- if eq .Values.provider "cri" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.nodeName }}-cni
+data:
+{{- range .Values.cniConfig }}
+  {{ .name }}: | {{- .data | nindent 4 -}}
+{{- end -}}
+{{- end -}}

--- a/charts/virtual-kubelet/templates/deployment.yaml
+++ b/charts/virtual-kubelet/templates/deployment.yaml
@@ -25,6 +25,24 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- if eq (required "You must specify a Virtual Kubelet provider" .Values.provider) "cri" }}
+{{- if eq (required "You must specify a CRI implementation to use" .Values.providers.cri.implementation) "containerd" }}
+{{- with .Values.criImplementations.containerd  }}
+      - name: containerd
+        image: {{ .image.repository}}:{{.image.tag}}
+        imagePullPolicy: {{ .image.pullPolicy }}
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: containerd-run
+            mountPath: /run/containerd
+          - name: containerd-data
+            mountPath: /var/lib/containerd
+          - name: cni-config
+            mountPath: /etc/cni/net.d
+{{- end }}
+{{- end }}
+{{- end }}
       - name: {{ template "vk.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -97,7 +115,7 @@ spec:
 {{- else }}
         - name: MASTER_URI
           value: {{ .masterUri }}
-{{- end }}          
+{{- end }}
 {{- end }}
 {{- end }}
 {{- if eq .Values.trace.exporter "jaeger" }}
@@ -113,10 +131,20 @@ spec:
         volumeMounts:
         - name: credentials
           mountPath: "/etc/virtual-kubelet"
+        - name: cri-log
+          mountPath: /var/log/vk-cri/
+        - name: cri-volumes
+          mountPath: /run/vk-cri/volumes/
 {{- if eq (required "You must specify a Virtual Kubelet provider" .Values.provider) "azure" }}
 {{- if .Values.providers.azure.targetAKS }}
         - name: acs-credential
           mountPath: "/etc/acs/azure.json"
+{{- end }}
+{{- end }}
+{{- if eq (required "You must specify a Virtual Kubelet provider" .Values.provider) "cri" }}
+{{- if eq (required "You must specify a CRI implementation to use" .Values.providers.cri.implementation) "containerd" }}
+        - name: containerd-run
+          mountPath: /run/containerd
 {{- end }}
 {{- end }}
         command: ["virtual-kubelet"]
@@ -152,6 +180,23 @@ spec:
         hostPath:
           path: /etc/kubernetes/azure.json
           type: File
+{{- end }}
+{{- end }}
+{{- if eq (required "You must specify a Virtual Kubelet provider" .Values.provider) "cri" }}
+{{- if eq (required "You must specify a Virtual Kubelet provider" .Values.providers.cri.implementation) "containerd" }}
+      - name: containerd-run
+        emptyDir: {}
+      - name: containerd-data
+        emptyDir: {}
+      - name: cri-log
+        emptyDir: {}
+      - name: cri-volumes
+        emptyDir: {}
+{{- if eq .Values.provider "cri" }}
+      - name: cni-config
+        configMap:
+          name: {{ .Values.nodeName}}-cni
+{{- end }}
 {{- end }}
 {{- end }}
       serviceAccountName: {{ if .Values.rbac.install }} "{{ template "vk.fullname" . }}" {{ end }}

--- a/charts/virtual-kubelet/values.yaml
+++ b/charts/virtual-kubelet/values.yaml
@@ -54,6 +54,24 @@ providers:
       subnetCidr: 
       clusterCidr: 
       kubeDnsIp: 
+  cri:
+    implementation: containerd
+
+criImplementations:
+  containerd:
+    image:
+      pullPolicy: Always
+      repository: cpuguy83/containerd
+      tag: v1.2.5
+
+cniConfig:
+  - name: "99-localhost.conf"
+    data: |-
+      {
+        "cniVersion": "0.2.0",
+        "name": "lo",
+        "type": "loopback"
+      }
 
 ## Install Default RBAC roles and bindings
 rbac:


### PR DESCRIPTION
When cri is chosen, containerd is run in the pod.

This makes spinning things up to test CRI a bit simpler.
Not exactly production ready but it's a start.