### PR TITLE
More Makefile enhancements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 COPY . /go/src/github.com/virtual-kubelet/virtual-kubelet
 WORKDIR /go/src/github.com/virtual-kubelet/virtual-kubelet
-ARG BUILD_TAGS="netgo osusergo"
+ARG BUILD_TAGS=""
 RUN make VK_BUILD_TAGS="${BUILD_TAGS}" build
 RUN cp bin/virtual-kubelet /usr/bin/virtual-kubelet
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 SHELL := /bin/bash
 IMPORT_PATH := github.com/virtual-kubelet/virtual-kubelet
+
 DOCKER_IMAGE := virtual-kubelet
 exec := $(DOCKER_IMAGE)
 github_repo := virtual-kubelet/virtual-kubelet
 binary := virtual-kubelet
-build_tags := netgo osusergo $(VK_BUILD_TAGS)
 
 include Makefile.e2e
 
@@ -21,13 +21,14 @@ all: test build
 # safebuild builds inside a docker container with no clingons from your $GOPATH
 safebuild:
 	@echo "Building..."
-	$Q docker build --build-arg BUILD_TAGS=$(build_tags) -t $(DOCKER_IMAGE):$(VERSION) .
+	$Q docker build --build-arg BUILD_TAGS="$(VK_BUILD_TAGS)" -t $(DOCKER_IMAGE):$(VERSION) .
 
 .PHONY: build
-build: build_tags_actual := $(shell scripts/process_build_tags.sh $(build_tags))
+build: build_tags := netgo osusergo
+build: OUTPUT_DIR ?= bin
 build: authors
 	@echo "Building..."
-	$Q CGO_ENABLED=0 go build -a --tags '$(build_tags_actual)' -ldflags '-extldflags "-static"' -o bin/$(binary) $(if $V,-v) $(VERSION_FLAGS) $(IMPORT_PATH)
+	$Q CGO_ENABLED=0 go build -a --tags '$(shell scripts/process_build_tags.sh $(build_tags) $(VK_BUILD_TAGS))' -ldflags '-extldflags "-static"' -o $(OUTPUT_DIR)/$(binary) $(if $V,-v) $(VERSION_FLAGS) $(IMPORT_PATH)
 
 .PHONY: tags
 tags:

--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -20,6 +20,12 @@ skaffold/%: skaffold.validate
 		-f $(PWD)/hack/skaffold/virtual-kubelet/skaffold.yml \
 		-p $(PROFILE)
 
+bin/e2e:
+	@mkdir -p bin/e2e
+
+bin/e2e/virtual-kubelet: bin/e2e
+	GOOS=linux GOARCH=amd64 $(MAKE) OUTPUT_DIR=$(@D) build
+
 # e2e runs the end-to-end test suite against the Kubernetes cluster targeted by the current kubeconfig.
 # It automatically deploys the virtual-kubelet with the mock provider by running "make skaffold MODE=run".
 # It is the caller's responsibility to cleanup the deployment after running this target (e.g. by running "make skaffold MODE=delete").
@@ -30,10 +36,9 @@ e2e: NODE_NAME := vkubelet-mock-0
 e2e: TAINT_KEY := virtual-kubelet.io/provider
 e2e: TAINT_VALUE := mock
 e2e: TAINT_EFFECT := NoSchedule
-e2e: tags_with_mock := $(VK_BUILD_TAGS) mock
-e2e: e2e.clean
-	GOOS=linux GOARCH=amd64 $(MAKE) VK_BUILD_TAGS="$(tags_with_mock)" build; \
-	$(MAKE) skaffold/run; \
+e2e: export VK_BUILD_TAGS += mock_provider
+e2e: e2e.clean bin/e2e/virtual-kubelet skaffold/run
+	@echo Running tests...
 	cd $(PWD)/test/e2e && go test -v -tags e2e ./... \
 		-kubeconfig=$(KUBECONFIG) \
 		-namespace=$(NAMESPACE) \
@@ -43,5 +48,7 @@ e2e: e2e.clean
 		-taint-effect=$(TAINT_EFFECT)
 
 .PHONY: e2e.clean
+e2e.clean: NODE_NAME ?= vkubelet-mock-0
 e2e.clean: skaffold/delete
-	kubectl delete --ignore-not-found node $(NODE_NAME)
+	kubectl delete --ignore-not-found node $(NODE_NAME); \
+	if [ -f bin/e2e/virtual-kubelet ]; then  rm bin/e2e/virtual-kubelet; fi

--- a/hack/skaffold/virtual-kubelet/Dockerfile
+++ b/hack/skaffold/virtual-kubelet/Dockerfile
@@ -5,7 +5,7 @@ ENV APISERVER_KEY_LOCATION /vkubelet-mock-0-key.pem
 ENV KUBELET_PORT 10250
 
 # Use the pre-built binary in "bin/virtual-kubelet".
-COPY bin/virtual-kubelet /virtual-kubelet
+COPY bin/e2e/virtual-kubelet /virtual-kubelet
 # Copy the configuration file for the mock provider.
 COPY hack/skaffold/virtual-kubelet/vkubelet-mock-0-cfg.json /vkubelet-mock-0-cfg.json
 # Copy the certificate for the HTTPS server.


### PR DESCRIPTION
Allows us to make use of of make's target deps instead of re-execing
make in our build target just for custom, one-shot environment changes.

Keeps e2e bin in bin/e2e/virtual-kubelet.