### PR TITLE
Use I/O stream for provider logs interface

### DIFF
--- a/providers/aws/fargate/cluster.go
+++ b/providers/aws/fargate/cluster.go
@@ -2,6 +2,8 @@ package fargate
 
 import (
 	"fmt"
+	"io"
+	"io/ioutil"
 	"log"
 	"strings"
 	"sync"
@@ -11,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/cpuguy83/strongerrors"
+	"github.com/virtual-kubelet/virtual-kubelet/providers"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 )
 
@@ -310,9 +313,9 @@ func (c *Cluster) RemovePod(tag string) {
 }
 
 // GetContainerLogs returns the logs of a container from this cluster.
-func (c *Cluster) GetContainerLogs(namespace, podName, containerName string, tail int) (string, error) {
+func (c *Cluster) GetContainerLogs(namespace, podName, containerName string, opts providers.ContainerLogOpts) (io.ReadCloser, error) {
 	if c.cloudWatchLogGroupName == "" {
-		return "", fmt.Errorf("logs not configured, please specify a \"CloudWatchLogGroupName\"")
+		return nil, fmt.Errorf("logs not configured, please specify a \"CloudWatchLogGroupName\"")
 	}
 
 	prefix := fmt.Sprintf("%s_%s", buildTaskDefinitionTag(c.name, namespace, podName), containerName)
@@ -321,18 +324,18 @@ func (c *Cluster) GetContainerLogs(namespace, podName, containerName string, tai
 		LogStreamNamePrefix: aws.String(prefix),
 	})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// Nothing logged yet.
 	if len(describeResult.LogStreams) == 0 {
-		return "", nil
+		return nil, nil
 	}
 
 	logs := ""
 
 	err = client.logsapi.GetLogEventsPages(&cloudwatchlogs.GetLogEventsInput{
-		Limit:         aws.Int64(int64(tail)),
+		Limit:         aws.Int64(int64(opts.Tail)),
 		LogGroupName:  aws.String(c.cloudWatchLogGroupName),
 		LogStreamName: describeResult.LogStreams[0].LogStreamName,
 	}, func(page *cloudwatchlogs.GetLogEventsOutput, lastPage bool) bool {
@@ -348,8 +351,8 @@ func (c *Cluster) GetContainerLogs(namespace, podName, containerName string, tai
 	})
 
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return logs, nil
+	return ioutil.NopCloser(strings.NewReader(logs)), nil
 }

--- a/providers/aws/provider.go
+++ b/providers/aws/provider.go
@@ -3,13 +3,13 @@ package aws
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"time"
 
 	"github.com/virtual-kubelet/virtual-kubelet/manager"
 	"github.com/virtual-kubelet/virtual-kubelet/providers"
 	"github.com/virtual-kubelet/virtual-kubelet/providers/aws/fargate"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -172,9 +172,9 @@ func (p *FargateProvider) GetPod(ctx context.Context, namespace, name string) (*
 }
 
 // GetContainerLogs retrieves the logs of a container by name from the provider.
-func (p *FargateProvider) GetContainerLogs(ctx context.Context, namespace, podName, containerName string, tail int) (string, error) {
+func (p *FargateProvider) GetContainerLogs(ctx context.Context, namespace, podName, containerName string, opts providers.ContainerLogOpts) (io.ReadCloser, error) {
 	log.Printf("Received GetContainerLogs request for %s/%s/%s.\n", namespace, podName, containerName)
-	return p.cluster.GetContainerLogs(namespace, podName, containerName, tail)
+	return p.cluster.GetContainerLogs(namespace, podName, containerName, opts)
 }
 
 // GetPodFullName retrieves the full pod name as defined in the provider context.

--- a/providers/huawei/cci.go
+++ b/providers/huawei/cci.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/cpuguy83/strongerrors"
@@ -298,8 +299,8 @@ func (p *CCIProvider) GetPod(ctx context.Context, namespace, name string) (*v1.P
 }
 
 // GetContainerLogs retrieves the logs of a container by name from the huawei CCI provider.
-func (p *CCIProvider) GetContainerLogs(ctx context.Context, namespace, podName, containerName string, tail int) (string, error) {
-	return "", nil
+func (p *CCIProvider) GetContainerLogs(ctx context.Context, namespace, podName, containerName string, opts providers.ContainerLogOpts) (io.ReadCloser, error) {
+	return ioutil.NopCloser(strings.NewReader("")), nil
 }
 
 // Get full pod name as defined in the provider context

--- a/providers/mock/mock.go
+++ b/providers/mock/mock.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/cpuguy83/strongerrors"
@@ -195,7 +197,7 @@ func (p *MockProvider) GetPod(ctx context.Context, namespace, name string) (pod 
 }
 
 // GetContainerLogs retrieves the logs of a container by name from the provider.
-func (p *MockProvider) GetContainerLogs(ctx context.Context, namespace, podName, containerName string, tail int) (string, error) {
+func (p *MockProvider) GetContainerLogs(ctx context.Context, namespace, podName, containerName string, opts providers.ContainerLogOpts) (io.ReadCloser, error) {
 	ctx, span := trace.StartSpan(ctx, "GetContainerLogs")
 	defer span.End()
 
@@ -203,7 +205,7 @@ func (p *MockProvider) GetContainerLogs(ctx context.Context, namespace, podName,
 	ctx = addAttributes(ctx, span, namespaceKey, namespace, nameKey, podName, containerNameKey, containerName)
 
 	log.G(ctx).Info("receive GetContainerLogs %q", podName)
-	return "", nil
+	return ioutil.NopCloser(strings.NewReader("")), nil
 }
 
 // Get full pod name as defined in the provider context

--- a/providers/nomad/nomad.go
+++ b/providers/nomad/nomad.go
@@ -3,14 +3,15 @@ package nomad
 import (
 	"context"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"strings"
 
+	nomad "github.com/hashicorp/nomad/api"
 	"github.com/virtual-kubelet/virtual-kubelet/manager"
 	"github.com/virtual-kubelet/virtual-kubelet/providers"
-
-	nomad "github.com/hashicorp/nomad/api"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -146,8 +147,8 @@ func (p *Provider) GetPod(ctx context.Context, namespace, name string) (pod *v1.
 }
 
 // GetContainerLogs retrieves the logs of a container by name from the provider.
-func (p *Provider) GetContainerLogs(ctx context.Context, namespace, podName, containerName string, tail int) (string, error) {
-	return "", nil
+func (p *Provider) GetContainerLogs(ctx context.Context, namespace, podName, containerName string, opts providers.ContainerLogOpts) (io.ReadCloser, error) {
+	return ioutil.NopCloser(strings.NewReader("")), nil
 }
 
 // GetPodFullName as defined in the provider context

--- a/providers/openstack/zun.go
+++ b/providers/openstack/zun.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gophercloud/gophercloud"
@@ -232,8 +235,8 @@ func (p *ZunProvider) GetPodStatus(ctx context.Context, namespace, name string) 
 	return &pod.Status, nil
 }
 
-func (p *ZunProvider) GetContainerLogs(ctx context.Context, namespace, podName, containerName string, tail int) (string, error) {
-	return "not support in Zun Provider", nil
+func (p *ZunProvider) GetContainerLogs(ctx context.Context, namespace, podName, containerName string, opts providers.ContainerLogOpts) (io.ReadCloser, error) {
+	return ioutil.NopCloser(strings.NewReader("not support in Zun Provider")), nil
 }
 
 // NodeConditions returns a list of conditions (Ready, OutOfDisk, etc), for updates to the node status

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"context"
 	"io"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
@@ -23,7 +24,7 @@ type Provider interface {
 	GetPod(ctx context.Context, namespace, name string) (*v1.Pod, error)
 
 	// GetContainerLogs retrieves the logs of a container by name from the provider.
-	GetContainerLogs(ctx context.Context, namespace, podName, containerName string, tail int) (string, error)
+	GetContainerLogs(ctx context.Context, namespace, podName, containerName string, opts ContainerLogOpts) (io.ReadCloser, error)
 
 	// RunInContainer executes a command in a container in the pod, copying data
 	// between in/out/err and the container's stdin/stdout/stderr.
@@ -52,6 +53,15 @@ type Provider interface {
 
 	// OperatingSystem returns the operating system the provider is for.
 	OperatingSystem() string
+}
+
+// ContainerLogOpts are used to pass along options to be set on the container
+// log stream.
+type ContainerLogOpts struct {
+	Tail       int
+	Since      time.Duration
+	LimitBytes int
+	Timestamps bool
 }
 
 // PodMetricsProvider is an optional interface that providers can implement to expose pod stats

--- a/providers/web/broker.go
+++ b/providers/web/broker.go
@@ -86,8 +86,7 @@ func (p *BrokerProvider) DeletePod(ctx context.Context, pod *v1.Pod) error {
 		return err
 	}
 
-	_, err = p.doRequest("DELETE", urlPath, podJSON, false)
-	return err
+	return checkResponseStatus(p.doRequest("DELETE", urlPath, podJSON))
 }
 
 // GetPod returns a pod by name that is being managed by the web server
@@ -110,20 +109,20 @@ func (p *BrokerProvider) GetPod(ctx context.Context, namespace, name string) (*v
 }
 
 // GetContainerLogs returns the logs of a container running in a pod by name.
-func (p *BrokerProvider) GetContainerLogs(ctx context.Context, namespace, podName, containerName string, tail int) (string, error) {
+func (p *BrokerProvider) GetContainerLogs(ctx context.Context, namespace, podName, containerName string, opts providers.ContainerLogOpts) (io.ReadCloser, error) {
 	urlPathStr := fmt.Sprintf(
 		"/getContainerLogs?namespace=%s&podName=%s&containerName=%s&tail=%d",
 		url.QueryEscape(namespace),
 		url.QueryEscape(podName),
 		url.QueryEscape(containerName),
-		tail)
+		opts.Tail)
 
-	response, err := p.doGetRequestBytes(urlPathStr)
-	if err != nil {
-		return "", err
+	r, err := p.doGetRequestRaw(urlPathStr)
+	if err := checkResponseStatus(r, err); err != nil {
+		return nil, err
 	}
 
-	return string(response), nil
+	return r.Body, nil
 }
 
 // Get full pod name as defined in the provider context
@@ -231,13 +230,16 @@ func (p *BrokerProvider) doGetRequest(urlPathStr string, v interface{}) error {
 	return json.Unmarshal(response, &v)
 }
 
-func (p *BrokerProvider) doGetRequestBytes(urlPathStr string) ([]byte, error) {
+func (p *BrokerProvider) doGetRequestRaw(urlPathStr string) (*http.Response, error) {
 	urlPath, err := url.Parse(urlPathStr)
 	if err != nil {
 		return nil, err
 	}
+	return p.doRequest("GET", urlPath, nil)
+}
 
-	return p.doRequest("GET", urlPath, nil, true)
+func (p *BrokerProvider) doGetRequestBytes(urlPathStr string) ([]byte, error) {
+	return readResponse(p.doGetRequestRaw(urlPathStr))
 }
 
 func (p *BrokerProvider) createUpdatePod(pod *v1.Pod, method, postPath string) error {
@@ -252,11 +254,10 @@ func (p *BrokerProvider) createUpdatePod(pod *v1.Pod, method, postPath string) e
 	if err != nil {
 		return err
 	}
-	_, err = p.doRequest(method, postPathURL, podJSON, false)
-	return err
+	return checkResponseStatus(p.doRequest(method, postPathURL, podJSON))
 }
 
-func (p *BrokerProvider) doRequest(method string, urlPath *url.URL, body []byte, readResponse bool) ([]byte, error) {
+func (p *BrokerProvider) doRequest(method string, urlPath *url.URL, body []byte) (*http.Response, error) {
 	// build full URL
 	requestURL := p.endpoint.ResolveReference(urlPath)
 
@@ -281,20 +282,33 @@ func (p *BrokerProvider) doRequest(method string, urlPath *url.URL, body []byte,
 		return nil, err
 	}
 
-	defer response.Body.Close()
-	if response.StatusCode < 200 || response.StatusCode > 299 {
-		switch response.StatusCode {
+	return response, nil
+}
+
+func checkResponseStatus(r *http.Response, err error) error {
+	if err != nil {
+		return err
+	}
+	if r.StatusCode < 200 || r.StatusCode > 299 {
+		switch r.StatusCode {
 		case http.StatusNotFound:
-			return nil, strongerrors.NotFound(errors.New(response.Status))
+			return strongerrors.NotFound(errors.New(r.Status))
 		default:
-			return nil, errors.New(response.Status)
+			return errors.New(r.Status)
 		}
 	}
+	return nil
+}
 
-	// read response body if asked to
-	if readResponse {
-		return ioutil.ReadAll(response.Body)
+func readResponse(r *http.Response, err error) ([]byte, error) {
+	if r.Body != nil {
+		defer r.Body.Close()
 	}
 
-	return nil, nil
+	if err := checkResponseStatus(r, err); err != nil {
+		return nil, err
+	}
+
+	lr := io.LimitReader(r.Body, 1e6)
+	return ioutil.ReadAll(lr)
 }

--- a/vkubelet/api/logs.go
+++ b/vkubelet/api/logs.go
@@ -9,11 +9,13 @@ import (
 	"github.com/cpuguy83/strongerrors"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
+	"github.com/virtual-kubelet/virtual-kubelet/log"
+	"github.com/virtual-kubelet/virtual-kubelet/providers"
 )
 
 // ContainerLogsBackend is used in place of backend implementations for getting container logs
 type ContainerLogsBackend interface {
-	GetContainerLogs(ctx context.Context, namespace, podName, containerName string, tail int) (string, error)
+	GetContainerLogs(ctx context.Context, namespace, podName, containerName string, opts providers.ContainerLogOpts) (io.ReadCloser, error)
 }
 
 // PodLogsHandlerFunc creates an http handler function from a provider to serve logs from a pod
@@ -40,12 +42,27 @@ func PodLogsHandlerFunc(p ContainerLogsBackend) http.HandlerFunc {
 			tail = t
 		}
 
-		podsLogs, err := p.GetContainerLogs(ctx, namespace, pod, container, tail)
+		// TODO(@cpuguy83): support v1.PodLogOptions
+		// The kubelet decoding here is not straight forward, so this needs to be disected
+
+		opts := providers.ContainerLogOpts{
+			Tail: tail,
+		}
+
+		logs, err := p.GetContainerLogs(ctx, namespace, pod, container, opts)
 		if err != nil {
 			return errors.Wrap(err, "error getting container logs?)")
 		}
 
-		if _, err := io.WriteString(w, podsLogs); err != nil {
+		defer logs.Close()
+
+		req.Header.Set("Transfer-Encoding", "chunked")
+
+		if _, ok := w.(writeFlusher); !ok {
+			log.G(ctx).Debug("http response writer does not support flushes")
+		}
+
+		if _, err := io.Copy(flushOnWrite(w), logs); err != nil {
 			return strongerrors.Unknown(errors.Wrap(err, "error writing response to client"))
 		}
 		return nil


### PR DESCRIPTION
Providers must still update the implementation to actually gain any
benefit here, but this makes the provider interface a bit more sane.