### PR TITLE
Don't set cancel function to nil on error

### DIFF
--- a/cmd/virtual-kubelet/commands/root/http.go
+++ b/cmd/virtual-kubelet/commands/root/http.go
@@ -57,9 +57,9 @@ func loadTLSConfig(certPath, keyPath string) (*tls.Config, error) {
 	}, nil
 }
 
-func setupHTTPServer(ctx context.Context, p providers.Provider, cfg *apiServerConfig) (cancel func(), retErr error) {
+func setupHTTPServer(ctx context.Context, p providers.Provider, cfg *apiServerConfig) (_ func(), retErr error) {
 	var closers []io.Closer
-	cancel = func() {
+	cancel := func() {
 		for _, c := range closers {
 			c.Close()
 		}


### PR DESCRIPTION
When setting up the http server we return a cancel function to close all
the listeners down.
The issue here is we set the cancel function to nil and thereby cause a
panic when there is an error and the `defer` attempts to call cancel.

This fix just don't set a named return value for the cancel function to
make sure we don't overwrite it with a `return nil, err`.
This ensures that the `defer` can still call `cancel()`.

Fixes #576