### PR TITLE
Fix exec parameter parsing

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1849,6 +1849,7 @@
     "k8s.io/client-go/tools/watch",
     "k8s.io/client-go/util/workqueue",
     "k8s.io/kubernetes/pkg/api/v1/pod",
+    "k8s.io/kubernetes/pkg/apis/core",
     "k8s.io/kubernetes/pkg/apis/core/pods",
     "k8s.io/kubernetes/pkg/apis/core/v1/helper",
     "k8s.io/kubernetes/pkg/fieldpath",


### PR DESCRIPTION
Exec seems to be broken by ad6fbba806a9470fc6d3feef636ee339632c4ab8
This change basically copies what's in `remotecommand.NewOptions`, just
without the logging.

Looking at unit testing this, but the unit test was significantly more complicated with a high chance of bugs than the actual code itself.
Another option is to outfit the mock provider with some exec capabilities... maybe in a separate PR.
I manually verified this functionality against ACI.