### PR TITLE
Stop using deprecated method Clientset.Coordination

### DIFF
--- a/cmd/virtual-kubelet/commands/root/root.go
+++ b/cmd/virtual-kubelet/commands/root/root.go
@@ -136,7 +136,7 @@ func runRootCommand(ctx context.Context, c Opts) error {
 	node, err := vkubelet.NewNode(
 		vkubelet.NaiveNodeProvider{},
 		pNode,
-		client.Coordination().Leases(corev1.NamespaceNodeLease),
+		client.CoordinationV1beta1().Leases(corev1.NamespaceNodeLease),
 		client.CoreV1().Nodes(),
 		vkubelet.WithNodeDisableLease(!c.EnableNodeLease),
 	)


### PR DESCRIPTION
Clientset.Coordination is deprecated. We are meant to use the specific
version of the client: CoordinationV1beta1. Clientset.Coordination is
going to be removed in future versions of the client API.