### PR TITLE
fix dereference nil pointer error when updatePodStatus

### DIFF
--- a/vkubelet/pod.go
+++ b/vkubelet/pod.go
@@ -192,6 +192,10 @@ func (s *Server) updatePodStatus(ctx context.Context, pod *corev1.Pod) error {
 			pod.Status.Reason = "NotFound"
 			pod.Status.Message = "The pod status was not found and may have been deleted from the provider"
 			for i, c := range pod.Status.ContainerStatuses {
+				// Skip waiting and Terminated status
+				if c.State.Waiting != nil || c.State.Terminated != nil {
+					continue
+				}
 				pod.Status.ContainerStatuses[i].State.Terminated = &corev1.ContainerStateTerminated{
 					ExitCode:    -137,
 					Reason:      "NotFound",


### PR DESCRIPTION
A pod in running state doesn't means its container also in running states. Like issue #583 
I catch some logs show a pod in running state but container in Waiting state:

```
{nginx 
{ContainerStateWaiting{Reason:CrashLoopBackOff,Message:Back-off 1m20s restarting failed container=nginx pod=default-nginx-deployment-7d6f46c7fb-bmp8w_eci-2ze4nwuvbq3zw94g39z5(XbHMbjeBvZwcJXyXLoet-default-nginx-deployment-7d6f46c7fb-bmp8w),} nil nil} 
{nil nil &ContainerStateTerminated{ExitCode:127,Signal:0,Reason:Error,Message:,StartedAt:2019-04-24 14:31:48 +0000 UTC,FinishedAt:2019-04-24 14:31:48 +0000 UTC,ContainerID:,}} 
false 4 nginx  eci://a657e387435a1b32d829058bfe7741d80ee5bf6f7505d27823ddeb7a3a9b3000}
```

Logic in `updatePodStatus` should skipping the `waiting` and `terminated` state, then change `running` to `terminated`. 