### PR TITLE
Add the concept of startup timeout

### DIFF
--- a/cmd/virtual-kubelet/commands/root/flag.go
+++ b/cmd/virtual-kubelet/commands/root/flag.go
@@ -78,7 +78,7 @@ func installFlags(flags *pflag.FlagSet, c *Opts) {
 	flags.StringVar(&c.TraceSampleRate, "trace-sample-rate", c.TraceSampleRate, "set probability of tracing samples")
 
 	flags.DurationVar(&c.InformerResyncPeriod, "full-resync-period", c.InformerResyncPeriod, "how often to perform a full resync of pods between kubernetes and the provider")
-
+	flags.DurationVar(&c.StartupTimeout, "startup-timeout", c.StartupTimeout, "How long to wait for the virtual-kubelet to start")
 }
 
 func getEnv(key, defaultValue string) string {

--- a/cmd/virtual-kubelet/commands/root/opts.go
+++ b/cmd/virtual-kubelet/commands/root/opts.go
@@ -78,6 +78,9 @@ type Opts struct {
 	TraceExporters  []string
 	TraceSampleRate string
 	TraceConfig     opencensus.TracingExporterOptions
+
+	// Startup Timeout is how long to wait for the kubelet to start
+	StartupTimeout time.Duration
 }
 
 // SetDefaultOpts sets default options for unset values on the passed in option struct.


### PR DESCRIPTION
This adds two concepts, where one encompasses the other.

### Startup timeout
Startup timeout is how long to wait for the entire kubelet
to get into a functional state. Right now, this only waits
for the pod informer cache for the pod controllerto become
in-sync with API server, but this could be extended to other
informers (like secrets informer).

### Wait For Startup
This changes the behaviour of the virtual kubelet to wait
for the pod controller to start before registering the node.

It is to avoid the race condition where the node is registered,
but we cannot actually do any pod operations.