### PR TITLE
Introduce Soft Deletes to allow for Terminal Status Updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,10 @@ jobs:
           command: |
             make e2e
       - run:
+          name: Run the end-to-end test suite
+          command: |
+            make e2e NODE_NAME=vkubelet-mock-1 STATS_PORT=10256
+      - run:
           name: Collect logs on failure from vkubelet-mock-0
           command: |
             kubectl logs vkubelet-mock-0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       CHANGE_MINIKUBE_NONE_USER: true
       GOPATH: /home/circleci/go
       KUBECONFIG: /home/circleci/.kube/config
-      KUBERNETES_VERSION: v1.12.3
+      KUBERNETES_VERSION: v1.13.4
       MINIKUBE_HOME: /home/circleci
       MINIKUBE_VERSION: v0.30.0
       MINIKUBE_WANTUPDATENOTIFICATION: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,14 @@ jobs:
               sleep 1;
             done
       - run:
+          name: Watch pods
+          command: kubectl get pods -o json --watch
+          background: true
+      - run:
+          name: Watch nodes
+          command: kubectl get nodes -o json --watch
+          background: true
+      - run:
           name: Run the end-to-end test suite
           command: |
             make e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,9 +103,14 @@ jobs:
           command: |
             make e2e
       - run:
-          name: Collect logs on failure
+          name: Collect logs on failure from vkubelet-mock-0
           command: |
             kubectl logs vkubelet-mock-0
+          when: on_fail
+      - run:
+          name: Collect logs on failure from vkubelet-mock-1
+          command: |
+            kubectl logs vkubelet-mock-1
           when: on_fail
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,11 @@ jobs:
           name: Run the end-to-end test suite
           command: |
             make e2e
+      - run:
+          name: Collect logs on failure
+          command: |
+            kubectl logs vkubelet-mock-0
+          when: on_fail
 
 workflows:
   version: 2

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1848,6 +1848,7 @@
     "k8s.io/client-go/tools/remotecommand",
     "k8s.io/client-go/tools/watch",
     "k8s.io/client-go/util/workqueue",
+    "k8s.io/klog",
     "k8s.io/kubernetes/pkg/api/v1/pod",
     "k8s.io/kubernetes/pkg/apis/core",
     "k8s.io/kubernetes/pkg/apis/core/pods",

--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -39,7 +39,7 @@ e2e: TAINT_EFFECT := NoSchedule
 e2e: export VK_BUILD_TAGS += mock_provider
 e2e: e2e.clean bin/e2e/virtual-kubelet skaffold/run
 	@echo Running tests...
-	cd $(PWD)/test/e2e && go test -v -tags e2e ./... \
+	cd $(PWD)/test/e2e && go test -v -timeout 5m -tags e2e ./... \
 		-kubeconfig=$(KUBECONFIG) \
 		-namespace=$(NAMESPACE) \
 		-node-name=$(NODE_NAME) \

--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -32,10 +32,11 @@ bin/e2e/virtual-kubelet: bin/e2e
 .PHONY: e2e
 e2e: KUBECONFIG ?= $(HOME)/.kube/config
 e2e: NAMESPACE := default
-e2e: NODE_NAME := vkubelet-mock-0
+e2e: NODE_NAME ?= vkubelet-mock-0
 e2e: TAINT_KEY := virtual-kubelet.io/provider
 e2e: TAINT_VALUE := mock
 e2e: TAINT_EFFECT := NoSchedule
+e2e: STATS_PORT ?= 10255
 e2e: export VK_BUILD_TAGS += mock_provider
 e2e: e2e.clean bin/e2e/virtual-kubelet skaffold/run
 	@echo Running tests...
@@ -45,8 +46,8 @@ e2e: e2e.clean bin/e2e/virtual-kubelet skaffold/run
 		-node-name=$(NODE_NAME) \
 		-taint-key=$(TAINT_KEY) \
 		-taint-value=$(TAINT_VALUE) \
-		-taint-effect=$(TAINT_EFFECT)
-
+		-taint-effect=$(TAINT_EFFECT) \
+		-stats-port=$(STATS_PORT)
 .PHONY: e2e.clean
 e2e.clean: NODE_NAME ?= vkubelet-mock-0
 e2e.clean: skaffold/delete

--- a/cmd/virtual-kubelet/commands/root/flag.go
+++ b/cmd/virtual-kubelet/commands/root/flag.go
@@ -15,6 +15,7 @@
 package root
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -22,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"github.com/virtual-kubelet/virtual-kubelet/trace/opencensus"
+	"k8s.io/klog"
 )
 
 type mapVar map[string]string
@@ -79,6 +81,13 @@ func installFlags(flags *pflag.FlagSet, c *Opts) {
 
 	flags.DurationVar(&c.InformerResyncPeriod, "full-resync-period", c.InformerResyncPeriod, "how often to perform a full resync of pods between kubernetes and the provider")
 	flags.DurationVar(&c.StartupTimeout, "startup-timeout", c.StartupTimeout, "How long to wait for the virtual-kubelet to start")
+
+	flagset := flag.NewFlagSet("klog", flag.PanicOnError)
+	klog.InitFlags(flagset)
+	flagset.VisitAll(func(f *flag.Flag) {
+		f.Name = "klog." + f.Name
+		flags.AddGoFlag(f)
+	})
 }
 
 func getEnv(key, defaultValue string) string {

--- a/cmd/virtual-kubelet/commands/root/http.go
+++ b/cmd/virtual-kubelet/commands/root/http.go
@@ -71,10 +71,18 @@ func setupHTTPServer(ctx context.Context, p providers.Provider, cfg *apiServerCo
 	}()
 
 	if cfg.CertPath == "" || cfg.KeyPath == "" {
-		log.G(ctx).
-			WithField("certPath", cfg.CertPath).
-			WithField("keyPath", cfg.KeyPath).
-			Error("TLS certificates not provided, not setting up pod http server")
+		mux := http.NewServeMux()
+		vkubelet.AttachPodRoutes(p, mux)
+
+		s := &http.Server{
+			Handler: mux,
+		}
+		l, err := net.Listen("tcp", cfg.Addr)
+		if err != nil {
+			return nil, errors.Wrap(err, "error setting up listener for pod http server")
+		}
+		go serveHTTP(ctx, s, l, "pods")
+		closers = append(closers, s)
 	} else {
 		tlsCfg, err := loadTLSConfig(cfg.CertPath, cfg.KeyPath)
 		if err != nil {

--- a/cmd/virtual-kubelet/commands/root/opts.go
+++ b/cmd/virtual-kubelet/commands/root/opts.go
@@ -117,8 +117,9 @@ func SetDefaultOpts(c *Opts) error {
 				return errors.Wrap(err, "error parsing KUBELET_PORT environment variable")
 			}
 			c.ListenPort = int32(p)
+		} else {
+			c.ListenPort = DefaultListenPort
 		}
-		c.ListenPort = DefaultListenPort
 	}
 
 	if c.KubeNamespace == "" {

--- a/hack/skaffold/virtual-kubelet/Dockerfile
+++ b/hack/skaffold/virtual-kubelet/Dockerfile
@@ -7,7 +7,7 @@ ENV KUBELET_PORT 10250
 # Use the pre-built binary in "bin/virtual-kubelet".
 COPY bin/e2e/virtual-kubelet /virtual-kubelet
 # Copy the configuration file for the mock provider.
-COPY hack/skaffold/virtual-kubelet/vkubelet-mock-0-cfg.json /vkubelet-mock-0-cfg.json
+COPY hack/skaffold/virtual-kubelet/vkubelet-mock-cfg.json /vkubelet-mock-cfg.json
 # Copy the certificate for the HTTPS server.
 COPY hack/skaffold/virtual-kubelet/vkubelet-mock-0-crt.pem /vkubelet-mock-0-crt.pem
 # Copy the private key for the HTTPS server.

--- a/hack/skaffold/virtual-kubelet/base.yml
+++ b/hack/skaffold/virtual-kubelet/base.yml
@@ -26,6 +26,7 @@ rules:
   - get
   - list
   - watch
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -45,6 +46,7 @@ rules:
   - pods/status
   verbs:
   - update
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/hack/skaffold/virtual-kubelet/base.yml
+++ b/hack/skaffold/virtual-kubelet/base.yml
@@ -13,6 +13,7 @@ rules:
   resources:
   - configmaps
   - secrets
+  - services
   verbs:
   - get
   - list
@@ -40,6 +41,7 @@ rules:
   - nodes/status
   verbs:
   - update
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/hack/skaffold/virtual-kubelet/pod.yml
+++ b/hack/skaffold/virtual-kubelet/pod.yml
@@ -1,8 +1,10 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
   name: vkubelet-mock-0
 spec:
+  serviceAccountName: virtual-kubelet
   containers:
   - name: vkubelet-mock-0
     image: virtual-kubelet
@@ -15,7 +17,7 @@ spec:
     - --provider
     - mock
     - --provider-config
-    - /vkubelet-mock-0-cfg.json
+    - /vkubelet-mock-cfg.json
     - --startup-timeout
     - 10s
     - --klog.v
@@ -30,4 +32,32 @@ spec:
       httpGet:
         path: /stats/summary
         port: metrics
-  serviceAccountName: virtual-kubelet
+  - name: vkubelet-mock-1
+    image:
+      virtual-kubelet
+    # "IfNotPresent" is used to prevent Minikube from trying to pull from the registry (and failing) in the first place.
+    imagePullPolicy: IfNotPresent
+    args:
+    - /virtual-kubelet
+    - --nodename
+    - vkubelet-mock-1
+    - --provider
+    - mock
+    - --provider-config
+    - /vkubelet-mock-cfg.json
+    - --startup-timeout
+    - 10s
+    - --klog.v
+    - "2"
+    - --klog.logtostderr
+    - --log-level
+    - debug
+    - --metrics-addr
+    - :10256
+    ports:
+    - name: metrics
+      containerPort: 10256
+    readinessProbe:
+      httpGet:
+        path: /stats/summary
+        port: metrics

--- a/hack/skaffold/virtual-kubelet/pod.yml
+++ b/hack/skaffold/virtual-kubelet/pod.yml
@@ -16,6 +16,13 @@ spec:
     - mock
     - --provider-config
     - /vkubelet-mock-0-cfg.json
+    - --startup-timeout
+    - 10s
+    - --klog.v
+    - "2"
+    - --klog.logtostderr
+    - --log-level
+    - debug
     ports:
     - name: metrics
       containerPort: 10255

--- a/hack/skaffold/virtual-kubelet/pod1.yml
+++ b/hack/skaffold/virtual-kubelet/pod1.yml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vkubelet-mock-0
+spec:
+  serviceAccountName: virtual-kubelet
+  containers:
+  - name: vkubelet-mock-0
+    image: virtual-kubelet
+    # "IfNotPresent" is used to prevent Minikube from trying to pull from the registry (and failing) in the first place.
+    imagePullPolicy: IfNotPresent
+    args:
+    - /virtual-kubelet
+    - --nodename
+    - vkubelet-mock-0
+    - --provider
+    - mock
+    - --provider-config
+    - /vkubelet-mock-cfg.json
+    - --startup-timeout
+    - 10s
+    - --klog.v
+    - "2"
+    - --klog.logtostderr
+    - --log-level
+    - debug
+    ports:
+    - name: metrics
+      containerPort: 10255
+    readinessProbe:
+      httpGet:
+        path: /stats/summary
+        port: metrics

--- a/hack/skaffold/virtual-kubelet/pod2.yml
+++ b/hack/skaffold/virtual-kubelet/pod2.yml
@@ -29,7 +29,7 @@ spec:
     - :10256
     env:
     - name: KUBELET_PORT
-      value: 10251
+      value: "10251"
     ports:
     - name: metrics
       containerPort: 10256

--- a/hack/skaffold/virtual-kubelet/pod2.yml
+++ b/hack/skaffold/virtual-kubelet/pod2.yml
@@ -2,39 +2,12 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: vkubelet-mock-0
+  name: vkubelet-mock-1
 spec:
   serviceAccountName: virtual-kubelet
   containers:
-  - name: vkubelet-mock-0
-    image: virtual-kubelet
-    # "IfNotPresent" is used to prevent Minikube from trying to pull from the registry (and failing) in the first place.
-    imagePullPolicy: IfNotPresent
-    args:
-    - /virtual-kubelet
-    - --nodename
-    - vkubelet-mock-0
-    - --provider
-    - mock
-    - --provider-config
-    - /vkubelet-mock-cfg.json
-    - --startup-timeout
-    - 10s
-    - --klog.v
-    - "2"
-    - --klog.logtostderr
-    - --log-level
-    - debug
-    ports:
-    - name: metrics
-      containerPort: 10255
-    readinessProbe:
-      httpGet:
-        path: /stats/summary
-        port: metrics
   - name: vkubelet-mock-1
-    image:
-      virtual-kubelet
+    image: virtual-kubelet
     # "IfNotPresent" is used to prevent Minikube from trying to pull from the registry (and failing) in the first place.
     imagePullPolicy: IfNotPresent
     args:
@@ -54,6 +27,9 @@ spec:
     - debug
     - --metrics-addr
     - :10256
+    env:
+    - name: KUBELET_PORT
+      value: 10251
     ports:
     - name: metrics
       containerPort: 10256

--- a/hack/skaffold/virtual-kubelet/skaffold.yml
+++ b/hack/skaffold/virtual-kubelet/skaffold.yml
@@ -11,6 +11,7 @@ deploy:
     manifests:
     - hack/skaffold/virtual-kubelet/base.yml
     - hack/skaffold/virtual-kubelet/pod1.yml
+    - hack/skaffold/virtual-kubelet/pod2.yml
 profiles:
 - name: local
   build:

--- a/hack/skaffold/virtual-kubelet/skaffold.yml
+++ b/hack/skaffold/virtual-kubelet/skaffold.yml
@@ -10,7 +10,7 @@ deploy:
   kubectl:
     manifests:
     - hack/skaffold/virtual-kubelet/base.yml
-    - hack/skaffold/virtual-kubelet/pod.yml
+    - hack/skaffold/virtual-kubelet/pod1.yml
 profiles:
 - name: local
   build:

--- a/hack/skaffold/virtual-kubelet/vkubelet-mock-0-cfg.json
+++ b/hack/skaffold/virtual-kubelet/vkubelet-mock-0-cfg.json
@@ -1,7 +1,0 @@
-{
-  "vkubelet-mock-0": {
-    "cpu": "2",
-    "memory": "32Gi",
-    "pods": "128"
-  }
-}

--- a/hack/skaffold/virtual-kubelet/vkubelet-mock-cfg.json
+++ b/hack/skaffold/virtual-kubelet/vkubelet-mock-cfg.json
@@ -1,0 +1,13 @@
+{
+  "vkubelet-mock-0": {
+    "cpu": "2",
+    "memory": "32Gi",
+    "pods": "128"
+  },
+  "vkubelet-mock-1": {
+    "cpu": "2",
+    "memory": "32Gi",
+    "pods": "128",
+    "disableSoftDeletes": true
+  }
+}

--- a/providers/mock/mock.go
+++ b/providers/mock/mock.go
@@ -41,6 +41,7 @@ type MockProvider struct {
 	pods               map[string]*v1.Pod
 	config             MockConfig
 	startTime          time.Time
+	notifier           func(*v1.Pod)
 }
 
 // MockConfig contains a mock virtual-kubelet's configurable parameters.
@@ -70,7 +71,6 @@ func NewMockProvider(providerConfig, nodeName, operatingSystem string, internalI
 }
 
 // loadConfig loads the given json configuration files.
-
 func loadConfig(providerConfig, nodeName string) (config MockConfig, err error) {
 	data, err := ioutil.ReadFile(providerConfig)
 	if err != nil {
@@ -114,125 +114,15 @@ func (p *MockProvider) CreatePod(ctx context.Context, pod *v1.Pod) error {
 	// Add the pod's coordinates to the current span.
 	ctx = addAttributes(ctx, span, namespaceKey, pod.Namespace, nameKey, pod.Name)
 
-	log.G(ctx).Info("receive CreatePod %q", pod.Name)
+	log.G(ctx).Infof("receive CreatePod %q", pod.Name)
 
 	key, err := buildKey(pod)
 	if err != nil {
 		return err
 	}
-
-	p.pods[key] = pod
-
-	return nil
-}
-
-// UpdatePod accepts a Pod definition and updates its reference.
-func (p *MockProvider) UpdatePod(ctx context.Context, pod *v1.Pod) error {
-	ctx, span := trace.StartSpan(ctx, "UpdatePod")
-	defer span.End()
-
-	// Add the pod's coordinates to the current span.
-	ctx = addAttributes(ctx, span, namespaceKey, pod.Namespace, nameKey, pod.Name)
-
-	log.G(ctx).Info("receive UpdatePod %q", pod.Name)
-
-	key, err := buildKey(pod)
-	if err != nil {
-		return err
-	}
-
-	p.pods[key] = pod
-
-	return nil
-}
-
-// DeletePod deletes the specified pod out of memory.
-func (p *MockProvider) DeletePod(ctx context.Context, pod *v1.Pod) (err error) {
-	ctx, span := trace.StartSpan(ctx, "DeletePod")
-	defer span.End()
-
-	// Add the pod's coordinates to the current span.
-	ctx = addAttributes(ctx, span, namespaceKey, pod.Namespace, nameKey, pod.Name)
-
-	log.G(ctx).Info("receive DeletePod %q", pod.Name)
-
-	key, err := buildKey(pod)
-	if err != nil {
-		return err
-	}
-
-	if _, exists := p.pods[key]; !exists {
-		return strongerrors.NotFound(fmt.Errorf("pod not found"))
-	}
-
-	delete(p.pods, key)
-
-	return nil
-}
-
-// GetPod returns a pod by name that is stored in memory.
-func (p *MockProvider) GetPod(ctx context.Context, namespace, name string) (pod *v1.Pod, err error) {
-	ctx, span := trace.StartSpan(ctx, "GetPod")
-	defer func() {
-		span.SetStatus(ocstatus.FromError(err))
-		span.End()
-	}()
-
-	// Add the pod's coordinates to the current span.
-	ctx = addAttributes(ctx, span, namespaceKey, namespace, nameKey, name)
-
-	log.G(ctx).Info("receive GetPod %q", name)
-
-	key, err := buildKeyFromNames(namespace, name)
-	if err != nil {
-		return nil, err
-	}
-
-	if pod, ok := p.pods[key]; ok {
-		return pod, nil
-	}
-	return nil, strongerrors.NotFound(fmt.Errorf("pod \"%s/%s\" is not known to the provider", namespace, name))
-}
-
-// GetContainerLogs retrieves the logs of a container by name from the provider.
-func (p *MockProvider) GetContainerLogs(ctx context.Context, namespace, podName, containerName string, tail int) (string, error) {
-	ctx, span := trace.StartSpan(ctx, "GetContainerLogs")
-	defer span.End()
-
-	// Add pod and container attributes to the current span.
-	ctx = addAttributes(ctx, span, namespaceKey, namespace, nameKey, podName, containerNameKey, containerName)
-
-	log.G(ctx).Info("receive GetContainerLogs %q", podName)
-	return "", nil
-}
-
-// Get full pod name as defined in the provider context
-// TODO: Implementation
-func (p *MockProvider) GetPodFullName(namespace string, pod string) string {
-	return ""
-}
-
-// RunInContainer executes a command in a container in the pod, copying data
-// between in/out/err and the container's stdin/stdout/stderr.
-func (p *MockProvider) RunInContainer(ctx context.Context, namespace, name, container string, cmd []string, attach providers.AttachIO) error {
-	log.G(context.TODO()).Info("receive ExecInContainer %q", container)
-	return nil
-}
-
-// GetPodStatus returns the status of a pod by name that is "running".
-// returns nil if a pod by that name is not found.
-func (p *MockProvider) GetPodStatus(ctx context.Context, namespace, name string) (*v1.PodStatus, error) {
-	ctx, span := trace.StartSpan(ctx, "GetPodStatus")
-	defer span.End()
-
-	// Add namespace and name as attributes to the current span.
-	ctx = addAttributes(ctx, span, namespaceKey, namespace, nameKey, name)
-
-	log.G(ctx).Info("receive GetPodStatus %q", name)
 
 	now := metav1.NewTime(time.Now())
-
-	status := &v1.PodStatus{
+	pod.Status = v1.PodStatus{
 		Phase:     v1.PodRunning,
 		HostIP:    "1.2.3.4",
 		PodIP:     "5.6.7.8",
@@ -253,13 +143,8 @@ func (p *MockProvider) GetPodStatus(ctx context.Context, namespace, name string)
 		},
 	}
 
-	pod, err := p.GetPod(ctx, namespace, name)
-	if err != nil {
-		return nil, err
-	}
-
 	for _, container := range pod.Spec.Containers {
-		status.ContainerStatuses = append(status.ContainerStatuses, v1.ContainerStatus{
+		pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, v1.ContainerStatus{
 			Name:         container.Name,
 			Image:        container.Image,
 			Ready:        true,
@@ -272,7 +157,129 @@ func (p *MockProvider) GetPodStatus(ctx context.Context, namespace, name string)
 		})
 	}
 
-	return status, nil
+	p.pods[key] = pod
+	p.notifier(pod)
+
+	return nil
+}
+
+// UpdatePod accepts a Pod definition and updates its reference.
+func (p *MockProvider) UpdatePod(ctx context.Context, pod *v1.Pod) error {
+	ctx, span := trace.StartSpan(ctx, "UpdatePod")
+	defer span.End()
+
+	// Add the pod's coordinates to the current span.
+	ctx = addAttributes(ctx, span, namespaceKey, pod.Namespace, nameKey, pod.Name)
+
+	log.G(ctx).Infof("receive UpdatePod %q", pod.Name)
+
+	key, err := buildKey(pod)
+	if err != nil {
+		return err
+	}
+
+	p.pods[key] = pod
+	p.notifier(pod)
+
+	return nil
+}
+
+// DeletePod deletes the specified pod out of memory.
+func (p *MockProvider) DeletePod(ctx context.Context, pod *v1.Pod) (err error) {
+	ctx, span := trace.StartSpan(ctx, "DeletePod")
+	defer span.End()
+
+	// Add the pod's coordinates to the current span.
+	ctx = addAttributes(ctx, span, namespaceKey, pod.Namespace, nameKey, pod.Name)
+
+	log.G(ctx).Infof("receive DeletePod %q", pod.Name)
+
+	key, err := buildKey(pod)
+	if err != nil {
+		return err
+	}
+
+	if _, exists := p.pods[key]; !exists {
+		return strongerrors.NotFound(fmt.Errorf("pod not found"))
+	}
+
+	//
+	pod.Status = v1.PodStatus{
+		Phase:  v1.PodSucceeded,
+		Reason: "MockProviderPodDeleted",
+	}
+	delete(p.pods, key)
+	p.notifier(pod)
+
+	return nil
+}
+
+// GetPod returns a pod by name that is stored in memory.
+func (p *MockProvider) GetPod(ctx context.Context, namespace, name string) (pod *v1.Pod, err error) {
+	ctx, span := trace.StartSpan(ctx, "GetPod")
+	defer func() {
+		span.SetStatus(ocstatus.FromError(err))
+		span.End()
+	}()
+
+	// Add the pod's coordinates to the current span.
+	ctx = addAttributes(ctx, span, namespaceKey, namespace, nameKey, name)
+
+	log.G(ctx).Infof("receive GetPod %q", name)
+
+	key, err := buildKeyFromNames(namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if pod, ok := p.pods[key]; ok {
+		return pod, nil
+	}
+	return nil, strongerrors.NotFound(fmt.Errorf("pod \"%s/%s\" is not known to the provider", namespace, name))
+}
+
+// GetContainerLogs retrieves the logs of a container by name from the provider.
+func (p *MockProvider) GetContainerLogs(ctx context.Context, namespace, podName, containerName string, tail int) (string, error) {
+	ctx, span := trace.StartSpan(ctx, "GetContainerLogs")
+	defer span.End()
+
+	// Add pod and container attributes to the current span.
+	ctx = addAttributes(ctx, span, namespaceKey, namespace, nameKey, podName, containerNameKey, containerName)
+
+	log.G(ctx).Infof("receive GetContainerLogs %q", podName)
+	return "", nil
+}
+
+// Get full pod name as defined in the provider context
+// TODO: Implementation
+func (p *MockProvider) GetPodFullName(namespace string, pod string) string {
+	return ""
+}
+
+// RunInContainer executes a command in a container in the pod, copying data
+// between in/out/err and the container's stdin/stdout/stderr.
+func (p *MockProvider) RunInContainer(ctx context.Context, namespace, name, container string, cmd []string, attach providers.AttachIO) error {
+	log.G(ctx).Infof("receive ExecInContainer %q", container)
+	return nil
+}
+
+// GetPodStatus returns the status of a pod by name that is "running".
+// returns nil if a pod by that name is not found.
+func (p *MockProvider) GetPodStatus(ctx context.Context, namespace, name string) (*v1.PodStatus, error) {
+	ctx, span := trace.StartSpan(ctx, "GetPodStatus")
+	defer span.End()
+
+	// Add namespace and name as attributes to the current span.
+	ctx = addAttributes(ctx, span, namespaceKey, namespace, nameKey, name)
+
+	log.G(ctx).Infof("receive GetPodStatus %q", name)
+
+	pod, err := p.GetPod(ctx, namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pod.Status, nil
 }
 
 // GetPods returns a list of all pods known to be "running".
@@ -464,6 +471,12 @@ func (p *MockProvider) GetStatsSummary(ctx context.Context) (*stats.Summary, err
 	// Return the dummy stats.
 	return res, nil
 }
+
+func (p *MockProvider) NotifyPods(ctx context.Context, notifier func(*v1.Pod)) {
+	p.notifier = notifier
+}
+
+func (p *MockProvider) SoftDeletes() {}
 
 func buildKeyFromNames(namespace string, name string) (string, error) {
 	return fmt.Sprintf("%s-%s", namespace, name), nil

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -70,6 +70,17 @@ type PodNotifier interface {
 	NotifyPods(context.Context, func(*v1.Pod))
 }
 
+// SoftDeletes makes it so that containers are not immediately deleted from API server upon termination
+// It is useful for providers that intend to have a terminal status update for a container.
+// All Soft Delete providers must also implement the PodNotifier interface.
+//
+// You must implement this if you intend to ever delete pods after deletion
+type SoftDeletes interface {
+	PodNotifier
+	// This method does nothing other than signal the provider is okay with soft-deletes.
+	SoftDeletes()
+}
+
 // AttachIO is used to pass in streams to attach to a container process
 type AttachIO interface {
 	Stdin() io.Reader

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -77,8 +77,8 @@ type PodNotifier interface {
 // You must implement this if you intend to ever delete pods after deletion
 type SoftDeletes interface {
 	PodNotifier
-	// This method does nothing other than signal the provider is okay with soft-deletes.
-	SoftDeletes()
+	// This method indicates the provider is okay with soft-deletes. Return true is the provider can handle them.
+	SoftDeletes() bool
 }
 
 // AttachIO is used to pass in streams to attach to a container process

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -258,6 +258,7 @@ func TestPodLifecycleForceDelete(t *testing.T) {
 
 	// Forcibly delete the pod.
 	if err := f.DeletePodImmediately(pod.Namespace, pod.Name); err != nil {
+		t.Logf("Last saw pod in state: %+v", podLast)
 		t.Fatal(err)
 	}
 	t.Log("Force deleted pod: ", pod.Name)

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -255,6 +255,7 @@ func TestPodLifecycleForceDelete(t *testing.T) {
 		}
 	}()
 
+	time.Sleep(deleteGracePeriodForProvider)
 	// Forcibly delete the pod.
 	if err := f.DeletePodImmediately(pod.Namespace, pod.Name); err != nil {
 		t.Logf("Last saw pod in state: %+v", podLast)

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	"github.com/virtual-kubelet/virtual-kubelet/vkubelet"
-	v1 "k8s.io/api/core/v1"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 )
@@ -35,7 +37,7 @@ func TestGetStatsSummary(t *testing.T) {
 	}()
 
 	// Wait for the "nginx-0-X" pod to be reported as running and ready.
-	if err := f.WaitUntilPodReady(pod.Namespace, pod.Name); err != nil {
+	if _, err := f.WaitUntilPodReady(pod.Namespace, pod.Name); err != nil {
 		t.Fatal(err)
 	}
 
@@ -68,43 +70,168 @@ func TestGetStatsSummary(t *testing.T) {
 // Then, it deletes one of the pods and verifies that the provider has been asked to delete it.
 // These verifications are made using the /stats/summary endpoint of the virtual-kubelet, by checking for the presence or absence of the pods.
 // Hence, the provider being tested must implement the PodMetricsProvider interface.
-func TestPodLifecycle(t *testing.T) {
-	// Create a pod with prefix "nginx-0-" having a single container.
-	pod0, err := f.CreatePod(f.CreateDummyPodObjectWithPrefix("nginx-0-", "foo"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Delete the "nginx-0-X" pod after the test finishes.
-	defer func() {
-		if err := f.DeletePod(pod0.Namespace, pod0.Name); err != nil && !apierrors.IsNotFound(err) {
-			t.Error(err)
-		}
-	}()
-	t.Log("Created pod: " + pod0.Name)
 
-	// Create a pod with prefix "nginx-1-" having a single container.
-	pod1, err := f.CreatePod(f.CreateDummyPodObjectWithPrefix("nginx-1-", "bar"))
+func TestPodLifecycleGracefulDelete(t1 *testing.T) {
+	t1.Run("softDeletesEnabled", func(t *testing.T) {
+		// vkubelet-mock-0 is configured with soft deletes enabled
+		testPodLifecycleGracefulDelete(t, "vkubelet-mock-0", true, func(pod *v1.Pod) {
+			// Wait for the pod to be deleted in a separate goroutine.
+			// This ensures that we don't possibly miss the MODIFIED/DELETED events due to establishing the watch too late in the process.
+			podCh := make(chan error)
+			var podLast *v1.Pod
+			go func() {
+				defer close(podCh) // Close the podCh channel, signaling we've observed deletion of the pod.
+				deletePhases := []v1.PodPhase{v1.PodSucceeded, v1.PodFailed}
+				var err error
+				// Wait for the "nginx-1-Y" pod to be reported as having been marked for deletion.
+				podLast, err = f.WaitUntilPodInPhase(pod.Namespace, pod.Name, deletePhases...)
+				if err != nil {
+					// Propagate the error to the outside so we can fail the test.
+					podCh <- err
+				}
+			}()
+
+			// Delete the pod.
+			if err := f.DeletePod(pod.Namespace, pod.Name); err != nil {
+				t.Fatal(err)
+			}
+			t.Log("Deleted pod: ", pod.Name)
+			// Wait for the delete event to be ACKed.
+			if err := <-podCh; err != nil {
+				t.Fatal(err)
+			}
+			// Give the provider some time to react to the MODIFIED/DELETED events before proceeding.
+			time.Sleep(deleteGracePeriodForProvider)
+
+			// Grab the stats from the provider.
+			stats, err := f.GetStatsSummary()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Make sure the pod DOES NOT exist in the slice of PodStats anymore.
+			if _, err := findPodInPodStats(stats, pod); err == nil {
+				t.Fatalf("expected to NOT find pod \"%s/%s\" in the slice of pod stats", pod.Namespace, pod.Name)
+			}
+
+			assert.Assert(t, podLast != nil)
+			assert.Equal(t, podLast.Status.Phase, v1.PodSucceeded)
+			assert.Assert(t, podLast.ObjectMeta.GetDeletionGracePeriodSeconds() != nil)
+			assert.Assert(t, *podLast.ObjectMeta.GetDeletionGracePeriodSeconds() > int64(0))
+
+			t.Logf("Pod ended as phase: %+v", podLast.Status.Phase)
+			t.Logf("Pod 0 ended as metadata: %+v", *podLast.ObjectMeta.GetDeletionGracePeriodSeconds())
+			assert.Equal(t, "true", podLast.ObjectMeta.Annotations["virtual-kubelet.io/softDelete"])
+		})
+	})
+
+	// vkubelet-mock-0 is configured with soft deletes disabled
+	t1.Run("softDeletesDisabled", func(t *testing.T) {
+		testPodLifecycleGracefulDelete(t, "vkubelet-mock-1", false, func(pod *v1.Pod) {
+			podCh := make(chan error)
+			var podLast *v1.Pod
+			go func() {
+				// Close the podCh channel, signaling we've observed deletion of the pod.
+				defer close(podCh)
+
+				var err error
+				podLast, err = f.WaitUntilPodDeleted(pod.Namespace, pod.Name)
+				if err != nil {
+					// Propagate the error to the outside so we can fail the test.
+					podCh <- err
+				}
+			}()
+
+			// Gracefully delete the "nginx-0" pod.
+			if err := f.DeletePod(pod.Namespace, pod.Name); err != nil {
+				t.Fatal(err)
+			}
+			t.Log("Force deleted pod: ", pod.Name)
+
+			// Wait for the delete event to be ACKed.
+			if err := <-podCh; err != nil {
+				t.Fatal(err)
+			}
+			// Give the provider some time to react to the MODIFIED/DELETED events before proceeding.
+			time.Sleep(deleteGracePeriodForProvider)
+			assert.Assert(t, podLast != nil)
+			assert.Assert(t, podLast.ObjectMeta.GetDeletionGracePeriodSeconds() != nil)
+			assert.Equal(t, int64(0), *podLast.ObjectMeta.GetDeletionGracePeriodSeconds())
+			assert.Assert(t, is.Nil(podLast.ObjectMeta.Annotations["virtual-kubelet.io/softDelete"]))
+		})
+	})
+}
+func testPodLifecycleGracefulDelete(t *testing.T, nodeName string, checkMetrics bool, check func(*v1.Pod)) {
+	// Create a pod with prefix "nginx-0-" having a single container.
+	podSpec := f.CreateDummyPodObjectWithPrefix("nginx-"+t.Name()+"-", "foo")
+	podSpec.Spec.NodeName = nodeName
+
+	pod, err := f.CreatePod(podSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Delete the "nginx-1-Y" pod after the test finishes.
+	// Delete the pod after the test finishes.
 	defer func() {
-		if err := f.DeletePod(pod1.Namespace, pod1.Name); err != nil && !apierrors.IsNotFound(err) {
+		if err := f.DeletePod(pod.Namespace, pod.Name); err != nil && !apierrors.IsNotFound(err) {
 			t.Error(err)
 		}
 	}()
-	t.Log("Created pod: " + pod1.Name)
+	t.Log("Created pod: " + pod.Name)
 
 	// Wait for the "nginx-0-X" pod to be reported as running and ready.
-	if err := f.WaitUntilPodReady(pod0.Namespace, pod0.Name); err != nil {
+	if _, err := f.WaitUntilPodReady(pod.Namespace, pod.Name); err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("Pod %s ready", pod0.Name)
-	// Wait for the "nginx-1-Y" pod to be reported as running and ready.
-	if err := f.WaitUntilPodReady(pod1.Namespace, pod1.Name); err != nil {
+	t.Logf("Pod %s ready", pod.Name)
+
+	if checkMetrics {
+		// Grab the stats from the provider.
+		stats, err := f.GetStatsSummary()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Make sure the "nginx-0-X" pod exists in the slice of PodStats.
+		if _, err := findPodInPodStats(stats, pod); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	check(pod)
+}
+
+// TestPodLifecycleNonGracefulDelete creates one podsand verifies that the provider has created them
+// and put them in the running lifecycle. It then does a force delete on the pod, and verifies the provider
+// has deleted it.
+func TestPodLifecycleForceDelete(t1 *testing.T) {
+	t1.Run("softDeletesEnabled", func(t *testing.T) {
+		testPodLifecycleForceDelete(t, "vkubelet-mock-0")
+	})
+	t1.Run("softDeletesDisabled", func(t *testing.T) {
+		testPodLifecycleForceDelete(t, "vkubelet-mock-1")
+	})
+}
+
+func testPodLifecycleForceDelete(t *testing.T, nodename string) {
+
+	// Create a pod with prefix having a single container.
+	pod, err := f.CreatePod(f.CreateDummyPodObjectWithPrefix("nginx-0-", "foo"))
+	if err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("Pod %s ready", pod1.Name)
+	// Delete the pod after the test finishes.
+	defer func() {
+		if err := f.DeletePod(pod.Namespace, pod.Name); err != nil && !apierrors.IsNotFound(err) {
+			t.Error(err)
+		}
+	}()
+	t.Log("Created pod: " + pod.Name)
+
+	// Wait for the "nginx-0-X" pod to be reported as running and ready.
+	if _, err := f.WaitUntilPodReady(pod.Namespace, pod.Name); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Pod %s ready", pod.Name)
 
 	// Grab the stats from the provider.
 	stats, err := f.GetStatsSummary()
@@ -112,76 +239,37 @@ func TestPodLifecycle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Make sure the "nginx-0-X" pod exists in the slice of PodStats.
-	if _, err := findPodInPodStats(stats, pod0); err != nil {
+	// Make sure the pod exists in the slice of PodStats.
+	if _, err := findPodInPodStats(stats, pod); err != nil {
 		t.Fatal(err)
 	}
 
-	// Make sure the "nginx-1-Y" pod exists in the slice of PodStats.
-	if _, err := findPodInPodStats(stats, pod1); err != nil {
-		t.Fatal(err)
-	}
-
-	// Wait for the "nginx-1-Y" pod to be deleted in a separate goroutine.
-	// This ensures that we don't possibly miss the MODIFIED/DELETED events due to establishing the watch too late in the process.
-	pod1Ch := make(chan error)
-	go func() {
-		// Wait for the "nginx-1-Y" pod to be reported as having been marked for deletion.
-		if err := f.WaitUntilPodInPhase(pod1.Namespace, pod1.Name, v1.PodSucceeded, v1.PodFailed); err != nil {
-			// Propagate the error to the outside so we can fail the test.
-			pod1Ch <- err
-		} else {
-			// Close the pod0Ch channel, signaling we've observed deletion of the pod.
-			close(pod1Ch)
-		}
-	}()
-
-	// Delete the "nginx-1" pod.
-	if err := f.DeletePod(pod1.Namespace, pod1.Name); err != nil {
-		t.Fatal(err)
-	}
-	t.Log("Deleted pod: ", pod1.Name)
-	// Wait for the delete event to be ACKed.
-	if err := <-pod1Ch; err != nil {
-		t.Fatal(err)
-	}
-	// Give the provider some time to react to the MODIFIED/DELETED events before proceeding.
-	time.Sleep(deleteGracePeriodForProvider)
-
-	// Grab the stats from the provider.
-	stats, err = f.GetStatsSummary()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Make sure the "nginx-1-Y" pod DOES NOT exist in the slice of PodStats anymore.
-	if _, err := findPodInPodStats(stats, pod1); err == nil {
-		t.Fatalf("expected to NOT find pod \"%s/%s\" in the slice of pod stats", pod1.Namespace, pod1.Name)
-	}
-
-	// Wait for the "nginx-0-X" pod to be deleted in a separate goroutine.
+	// Wait for the pod to be deleted in a separate goroutine.
 	// This ensures that we don't possibly miss the MODIFIED/DELETED events due to establishing the watch too late in the process.
 	// It also makes sure that in light of soft deletes, we properly handle non-graceful pod deletion
-	pod0Ch := make(chan error)
+	podCh := make(chan error)
+	var podLast *v1.Pod
 	go func() {
-		// Wait for the "nginx-0-X" pod to be reported as having been deleted.
-		if err := f.WaitUntilPodDeleted(pod0.Namespace, pod0.Name); err != nil {
+		// Close the podCh channel, signaling we've observed deletion of the pod.
+		defer close(podCh)
+
+		var err error
+		// Wait for the pod to be reported as having been deleted.
+		podLast, err = f.WaitUntilPodDeleted(pod.Namespace, pod.Name)
+		if err != nil {
 			// Propagate the error to the outside so we can fail the test.
-			pod0Ch <- err
-		} else {
-			// Close the pod0Ch channel, signaling we've observed deletion of the pod.
-			close(pod0Ch)
+			podCh <- err
 		}
 	}()
 
-	// Forcibly delete the "nginx-0" pod.
-	if err := f.DeletePodImmediately(pod0.Namespace, pod0.Name); err != nil {
+	// Forcibly delete the pod.
+	if err := f.DeletePodImmediately(pod.Namespace, pod.Name); err != nil {
 		t.Fatal(err)
 	}
-	t.Log("Force deleted pod: ", pod0.Name)
+	t.Log("Force deleted pod: ", pod.Name)
 
 	// Wait for the delete event to be ACKed.
-	if err := <-pod0Ch; err != nil {
+	if err := <-podCh; err != nil {
 		t.Fatal(err)
 	}
 	// Give the provider some time to react to the MODIFIED/DELETED events before proceeding.
@@ -194,9 +282,13 @@ func TestPodLifecycle(t *testing.T) {
 	}
 
 	// Make sure the "nginx-0-X" pod DOES NOT exist in the slice of PodStats anymore.
-	if _, err := findPodInPodStats(stats, pod0); err == nil {
-		t.Fatalf("expected to NOT find pod \"%s/%s\" in the slice of pod stats", pod0.Namespace, pod0.Name)
+	if _, err := findPodInPodStats(stats, pod); err == nil {
+		t.Fatalf("expected to NOT find pod \"%s/%s\" in the slice of pod stats", pod.Namespace, pod.Name)
 	}
+
+	t.Logf("Pod 0 ended as phase: %+v", podLast.Status.Phase)
+	t.Logf("Pod 0 ended as phase: %+v", *podLast.GetObjectMeta().GetDeletionGracePeriodSeconds())
+
 }
 
 // TestCreatePodWithOptionalInexistentSecrets tries to create a pod referencing optional, inexistent secrets.
@@ -216,7 +308,7 @@ func TestCreatePodWithOptionalInexistentSecrets(t *testing.T) {
 	}()
 
 	// Wait for the pod to be reported as running and ready.
-	if err := f.WaitUntilPodReady(pod.Namespace, pod.Name); err != nil {
+	if _, err := f.WaitUntilPodReady(pod.Namespace, pod.Name); err != nil {
 		t.Fatal(err)
 	}
 
@@ -283,7 +375,7 @@ func TestCreatePodWithOptionalInexistentConfigMap(t *testing.T) {
 	}()
 
 	// Wait for the pod to be reported as running and ready.
-	if err := f.WaitUntilPodReady(pod.Namespace, pod.Name); err != nil {
+	if _, err := f.WaitUntilPodReady(pod.Namespace, pod.Name); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -130,7 +130,6 @@ func testPodLifecycleGracefulDeleteSoftDeletesEnabled(t *testing.T) {
 	assert.Assert(t, *podLast.ObjectMeta.GetDeletionGracePeriodSeconds() > int64(0))
 
 	t.Logf("Pod ended as phase: %+v", podLast.Status.Phase)
-	t.Logf("Pod 0 ended as metadata: %+v", *podLast.ObjectMeta.GetDeletionGracePeriodSeconds())
 	assert.Equal(t, "true", podLast.ObjectMeta.Annotations["virtual-kubelet.io/softDelete"])
 }
 func testPodLifecycleGracefulDeleteSoftDeletesDisabled(t *testing.T) {
@@ -265,6 +264,7 @@ func TestPodLifecycleForceDelete(t *testing.T) {
 
 	// Wait for the delete event to be ACKed.
 	if err := <-podCh; err != nil {
+		t.Logf("Last saw pod in state: %+v", podLast)
 		t.Fatal(err)
 	}
 	// Give the provider some time to react to the MODIFIED/DELETED events before proceeding.

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -14,10 +14,11 @@ type Framework struct {
 	TaintKey    string
 	TaintValue  string
 	TaintEffect string
+	StatsPort   int
 }
 
 // NewTestingFramework returns a new instance of the testing framework.
-func NewTestingFramework(kubeconfig, namespace, nodeName, taintKey, taintValue, taintEffect string) *Framework {
+func NewTestingFramework(kubeconfig, namespace, nodeName, taintKey, taintValue, taintEffect string, statsPort int) *Framework {
 	return &Framework{
 		KubeClient:  createKubeClient(kubeconfig),
 		Namespace:   namespace,
@@ -25,6 +26,7 @@ func NewTestingFramework(kubeconfig, namespace, nodeName, taintKey, taintValue, 
 		TaintKey:    taintKey,
 		TaintValue:  taintValue,
 		TaintEffect: taintEffect,
+		StatsPort:   statsPort,
 	}
 }
 

--- a/test/e2e/framework/node.go
+++ b/test/e2e/framework/node.go
@@ -56,3 +56,8 @@ func (f *Framework) WaitUntilNodeAdded(event watchapi.Event) (bool, error) {
 func (f *Framework) DeleteNode() error {
 	return f.KubeClient.CoreV1().Nodes().Delete(f.NodeName, nil)
 }
+
+// GetNode gets the vk nodeused by the framework
+func (f *Framework) GetNode() (*corev1.Node, error) {
+	return f.KubeClient.CoreV1().Nodes().Get(f.NodeName, metav1.GetOptions{})
+}

--- a/test/e2e/framework/node.go
+++ b/test/e2e/framework/node.go
@@ -54,7 +54,13 @@ func (f *Framework) WaitUntilNodeAdded(event watchapi.Event) (bool, error) {
 
 // DeleteNode deletes the vk node used by the framework
 func (f *Framework) DeleteNode() error {
-	return f.KubeClient.CoreV1().Nodes().Delete(f.NodeName, nil)
+	var gracePeriod int64
+	propagation := metav1.DeletePropagationBackground
+	opts := metav1.DeleteOptions{
+		PropagationPolicy:  &propagation,
+		GracePeriodSeconds: &gracePeriod,
+	}
+	return f.KubeClient.CoreV1().Nodes().Delete(f.NodeName, &opts)
 }
 
 // GetNode gets the vk nodeused by the framework

--- a/test/e2e/framework/pod.go
+++ b/test/e2e/framework/pod.go
@@ -117,7 +117,7 @@ func (f *Framework) WaitUntilPodReady(namespace, name string) (*corev1.Pod, erro
 func (f *Framework) WaitUntilPodDeleted(namespace, name string) (*corev1.Pod, error) {
 	return f.WaitUntilPodCondition(namespace, name, func(event watchapi.Event) (bool, error) {
 		pod := event.Object.(*corev1.Pod)
-		return event.Type == watchapi.Deleted || (pod.ObjectMeta.DeletionTimestamp != nil && *pod.ObjectMeta.GetDeletionGracePeriodSeconds() == 0), nil
+		return event.Type == watchapi.Deleted || pod.ObjectMeta.DeletionTimestamp != nil, nil
 	})
 }
 

--- a/test/e2e/framework/pod.go
+++ b/test/e2e/framework/pod.go
@@ -16,7 +16,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 )
 
-const defaultWatchTimeout = 30 * time.Second
+const defaultWatchTimeout = 2 * time.Minute
 
 // CreateDummyPodObjectWithPrefix creates a dujmmy pod object using the specified prefix as the value of .metadata.generateName.
 // A variable number of strings can be provided.
@@ -116,8 +116,8 @@ func (f *Framework) WaitUntilPodReady(namespace, name string) (*corev1.Pod, erro
 // WaitUntilPodDeleted blocks until the pod with the specified name and namespace is deleted from apiserver.
 func (f *Framework) WaitUntilPodDeleted(namespace, name string) (*corev1.Pod, error) {
 	return f.WaitUntilPodCondition(namespace, name, func(event watchapi.Event) (bool, error) {
-		//		pod := event.Object.(*corev1.Pod)
-		return event.Type == watchapi.Deleted, nil
+		pod := event.Object.(*corev1.Pod)
+		return event.Type == watchapi.Deleted || (pod.ObjectMeta.DeletionTimestamp != nil && *pod.ObjectMeta.GetDeletionGracePeriodSeconds() == 0), nil
 	})
 }
 

--- a/test/e2e/framework/pod.go
+++ b/test/e2e/framework/pod.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -15,16 +16,16 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 )
 
-const (
-	defaultWatchTimeout       = 2 * time.Minute
-	hostnameNodeSelectorLabel = "kubernetes.io/hostname"
-)
+const defaultWatchTimeout = 30 * time.Second
 
 // CreateDummyPodObjectWithPrefix creates a dujmmy pod object using the specified prefix as the value of .metadata.generateName.
 // A variable number of strings can be provided.
 // For each one of these strings, a container that uses the string as its image will be appended to the pod.
 // This method DOES NOT create the pod in the Kubernetes API.
 func (f *Framework) CreateDummyPodObjectWithPrefix(prefix string, images ...string) *corev1.Pod {
+	// Safe the prefix
+	prefix = strings.Replace(prefix, "/", "-", -1)
+	prefix = strings.ToLower(prefix)
 	enableServiceLink := false
 
 	pod := &corev1.Pod{
@@ -33,9 +34,7 @@ func (f *Framework) CreateDummyPodObjectWithPrefix(prefix string, images ...stri
 			Namespace:    f.Namespace,
 		},
 		Spec: corev1.PodSpec{
-			NodeSelector: map[string]string{
-				hostnameNodeSelectorLabel: f.NodeName,
-			},
+			NodeName: f.NodeName,
 			Tolerations: []corev1.Toleration{
 				{
 					Key:    f.TaintKey,
@@ -78,7 +77,7 @@ func (f *Framework) DeletePodImmediately(namespace, name string) error {
 
 // WaitUntilPodCondition establishes a watch on the pod with the specified name and namespace.
 // Then, it waits for the specified condition function to be verified.
-func (f *Framework) WaitUntilPodCondition(namespace, name string, fn watch.ConditionFunc) error {
+func (f *Framework) WaitUntilPodCondition(namespace, name string, fn watch.ConditionFunc) (*corev1.Pod, error) {
 	// Create a field selector that matches the specified Pod resource.
 	fs := fields.ParseSelectorOrDie(fmt.Sprintf("metadata.namespace==%s,metadata.name==%s", namespace, name))
 	// Create a ListWatch so we can receive events for the matched Pod resource.
@@ -97,32 +96,33 @@ func (f *Framework) WaitUntilPodCondition(namespace, name string, fn watch.Condi
 	defer cfn()
 	last, err := watch.UntilWithSync(ctx, lw, &corev1.Pod{}, nil, fn)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if last == nil {
-		return fmt.Errorf("no events received for pod %q", name)
+		return nil, fmt.Errorf("no events received for pod %q", name)
 	}
-	return nil
+	pod := last.Object.(*corev1.Pod)
+	return pod, nil
 }
 
 // WaitUntilPodReady blocks until the pod with the specified name and namespace is reported to be running and ready.
-func (f *Framework) WaitUntilPodReady(namespace, name string) error {
+func (f *Framework) WaitUntilPodReady(namespace, name string) (*corev1.Pod, error) {
 	return f.WaitUntilPodCondition(namespace, name, func(event watchapi.Event) (bool, error) {
 		pod := event.Object.(*corev1.Pod)
 		return pod.Status.Phase == corev1.PodRunning && podutil.IsPodReady(pod) && pod.Status.PodIP != "", nil
 	})
 }
 
-// WaitUntilPodDeleted blocks until the pod with the specified name and namespace is marked for deletion (or, alternatively, effectively deleted).
-func (f *Framework) WaitUntilPodDeleted(namespace, name string) error {
+// WaitUntilPodDeleted blocks until the pod with the specified name and namespace is deleted from apiserver.
+func (f *Framework) WaitUntilPodDeleted(namespace, name string) (*corev1.Pod, error) {
 	return f.WaitUntilPodCondition(namespace, name, func(event watchapi.Event) (bool, error) {
-		pod := event.Object.(*corev1.Pod)
-		return event.Type == watchapi.Deleted || pod.DeletionTimestamp != nil, nil
+		//		pod := event.Object.(*corev1.Pod)
+		return event.Type == watchapi.Deleted, nil
 	})
 }
 
 // WaitUntilPodInPhase blocks until the pod with the specified name and namespace is in one of the specified phases
-func (f *Framework) WaitUntilPodInPhase(namespace, name string, phases ...corev1.PodPhase) error {
+func (f *Framework) WaitUntilPodInPhase(namespace, name string, phases ...corev1.PodPhase) (*corev1.Pod, error) {
 	return f.WaitUntilPodCondition(namespace, name, func(event watchapi.Event) (bool, error) {
 		pod := event.Object.(*corev1.Pod)
 		for _, p := range phases {

--- a/test/e2e/framework/pod.go
+++ b/test/e2e/framework/pod.go
@@ -121,6 +121,19 @@ func (f *Framework) WaitUntilPodDeleted(namespace, name string) error {
 	})
 }
 
+// WaitUntilPodInPhase blocks until the pod with the specified name and namespace is in one of the specified phases
+func (f *Framework) WaitUntilPodInPhase(namespace, name string, phases ...corev1.PodPhase) error {
+	return f.WaitUntilPodCondition(namespace, name, func(event watchapi.Event) (bool, error) {
+		pod := event.Object.(*corev1.Pod)
+		for _, p := range phases {
+			if pod.Status.Phase == p {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
 // WaitUntilPodEventWithReason establishes a watch on events involving the specified pod.
 // Then, it waits for an event with the specified reason to be created/updated.
 func (f *Framework) WaitUntilPodEventWithReason(pod *corev1.Pod, reason string) error {

--- a/test/e2e/framework/stats.go
+++ b/test/e2e/framework/stats.go
@@ -17,7 +17,7 @@ func (f *Framework) GetStatsSummary() (*stats.Summary, error) {
 		Namespace(f.Namespace).
 		Resource("pods").
 		SubResource("proxy").
-		Name(net.JoinSchemeNamePort("http", f.NodeName, strconv.Itoa(10255))).
+		Name(net.JoinSchemeNamePort("http", f.NodeName, strconv.Itoa(f.StatsPort))).
 		Suffix("/stats/summary").DoRaw()
 	if err != nil {
 		return nil, err

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -18,6 +18,7 @@ const (
 	defaultTaintKey    = "virtual-kubelet.io/provider"
 	defaultTaintValue  = "mock"
 	defaultTaintEffect = string(v1.TaintEffectNoSchedule)
+	defaultStatsPort   = 10255
 )
 
 var (
@@ -38,6 +39,8 @@ var (
 	taintEffect string
 	// Wait for Kubelet pod to come up before running tests
 	waitForKubelet bool
+	// Port that the statistics daemon is running on on the kubelet
+	statsPort int
 )
 
 func init() {
@@ -48,6 +51,7 @@ func init() {
 	flag.StringVar(&taintValue, "taint-value", defaultTaintValue, "the value of the taint that is expected to be associated with the virtual-kubelet node to test")
 	flag.StringVar(&taintEffect, "taint-effect", defaultTaintEffect, "the effect of the taint that is expected to be associated with the virtual-kubelet node to test")
 	flag.BoolVar(&waitForKubelet, "wait-for-kubelet", true, "Wait for Kubelet pod to come up before running tests")
+	flag.IntVar(&statsPort, "stats-port", defaultStatsPort, "Port that the statistics daemon is running on on the kubelet")
 }
 
 func TestMain(m *testing.M) {
@@ -55,7 +59,7 @@ func TestMain(m *testing.M) {
 	// Set sane defaults in case no values (or empty ones) have been provided.
 	setDefaults()
 	// Create a new instance of the test framework targeting the specified node.
-	f = framework.NewTestingFramework(kubeconfig, namespace, nodeName, taintKey, taintValue, taintEffect)
+	f = framework.NewTestingFramework(kubeconfig, namespace, nodeName, taintKey, taintValue, taintEffect, statsPort)
 	if waitForKubelet {
 		// Wait for the virtual-kubelet pod to be ready.
 		if _, err := f.WaitUntilPodReady(namespace, nodeName); err != nil {
@@ -82,5 +86,8 @@ func setDefaults() {
 	}
 	if taintEffect == "" {
 		taintEffect = defaultTaintEffect
+	}
+	if statsPort == 0 {
+		statsPort = defaultStatsPort
 	}
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -58,7 +58,7 @@ func TestMain(m *testing.M) {
 	f = framework.NewTestingFramework(kubeconfig, namespace, nodeName, taintKey, taintValue, taintEffect)
 	if waitForKubelet {
 		// Wait for the virtual-kubelet pod to be ready.
-		if err := f.WaitUntilPodReady(namespace, nodeName); err != nil {
+		if _, err := f.WaitUntilPodReady(namespace, nodeName); err != nil {
 			panic(err)
 		}
 	}

--- a/test/e2e/node_test.go
+++ b/test/e2e/node_test.go
@@ -17,8 +17,8 @@ func TestNodeCreateAfterDelete(t *testing.T) {
 	chDone := make(chan struct{})
 	defer close(chDone)
 
+	var deleted bool
 	go func() {
-		var deleted bool
 		wait := func(e watchapi.Event) (bool, error) {
 			select {
 			case <-chDone:
@@ -44,6 +44,7 @@ func TestNodeCreateAfterDelete(t *testing.T) {
 
 	select {
 	case <-timer.C:
+		t.Logf("Observed deletion: %v", deleted)
 		t.Fatal("timeout waiting for node to be recreated")
 	case err := <-chErr:
 		assert.NilError(t, err)

--- a/vkubelet/podcontroller.go
+++ b/vkubelet/podcontroller.go
@@ -221,6 +221,7 @@ func (pc *PodController) syncHandler(ctx context.Context, key string) error {
 			span.SetStatus(ocstatus.FromError(err))
 			return err
 		}
+
 		return nil
 	}
 	// At this point we know the Pod resource has either been created or updated (which includes being marked for deletion).

--- a/vkubelet/vkubelet.go
+++ b/vkubelet/vkubelet.go
@@ -2,6 +2,7 @@ package vkubelet
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -65,15 +66,22 @@ func New(cfg Config) *Server {
 // info to the Kubernetes API Server, such as logs, metrics, exec, etc.
 // See `AttachPodRoutes` and `AttachMetricsRoutes` to set these up.
 func (s *Server) Run(ctx context.Context) error {
-	q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "podStatusUpdate")
-	s.runProviderSyncWorkers(ctx, q)
+	workers := make([]workqueue.RateLimitingInterface, s.podSyncWorkers)
+
+	for idx := range workers {
+		name := fmt.Sprintf("podStatusUpdate-%d", idx)
+		q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), name)
+		workerID := strconv.Itoa(idx)
+		go s.runProviderSyncWorker(ctx, workerID, q)
+		workers[idx] = q
+	}
 
 	if pn, ok := s.provider.(providers.PodNotifier); ok {
 		pn.NotifyPods(ctx, func(pod *corev1.Pod) {
-			s.enqueuePodStatusUpdate(ctx, q, pod)
+			s.enqueuePodStatusUpdateWithPod(ctx, workers, pod)
 		})
 	} else {
-		go s.providerSyncLoop(ctx, q)
+		go s.providerSyncLoop(ctx, workers)
 	}
 
 	pc := NewPodController(s)
@@ -103,7 +111,7 @@ func (s *Server) Ready() <-chan struct{} {
 // Deprecated: This is only used when the provider does not support async updates
 // Providers should implement async update support, even if it just means copying
 // something like this in.
-func (s *Server) providerSyncLoop(ctx context.Context, q workqueue.RateLimitingInterface) {
+func (s *Server) providerSyncLoop(ctx context.Context, q []workqueue.RateLimitingInterface) {
 	const sleepTime = 5 * time.Second
 
 	t := time.NewTimer(sleepTime)
@@ -126,15 +134,6 @@ func (s *Server) providerSyncLoop(ctx context.Context, q workqueue.RateLimitingI
 	}
 }
 
-func (s *Server) runProviderSyncWorkers(ctx context.Context, q workqueue.RateLimitingInterface) {
-	for i := 0; i < s.podSyncWorkers; i++ {
-		go func(index int) {
-			workerID := strconv.Itoa(index)
-			s.runProviderSyncWorker(ctx, workerID, q)
-		}(i)
-	}
-}
-
 func (s *Server) runProviderSyncWorker(ctx context.Context, workerID string, q workqueue.RateLimitingInterface) {
 	for s.processPodStatusUpdate(ctx, workerID, q) {
 	}
@@ -147,5 +146,5 @@ func (s *Server) processPodStatusUpdate(ctx context.Context, workerID string, q 
 	// Add the ID of the current worker as an attribute to the current span.
 	ctx = span.WithField(ctx, "workerID", workerID)
 
-	return handleQueueItem(ctx, q, s.podStatusHandler)
+	return handleQueueItem(ctx, q)
 }


### PR DESCRIPTION
This introduces the concept of soft deletes, so that the
virtual-kubelet can make a call to API server to update
the pod and set the terminal state.

The mechanism of action is that if soft deletes are enabled
(by the user), the kubelet will then not actually delete
the pod from apiserver, but instead set an annotation
indicating that it has been deleted. Then, on subsequent
updates, it will not make the callback to the provider
to repeat deleting the pod.

Although this is a user-facing option in this PR, it also
makes it so that when you initialize the pod controller, you
can state whether you want this behaviour or not.