### PR TITLE
Backport: Fix exec parameter parsing (#580)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1905,6 +1905,7 @@
     "k8s.io/client-go/tools/watch",
     "k8s.io/client-go/util/workqueue",
     "k8s.io/kubernetes/pkg/api/v1/pod",
+    "k8s.io/kubernetes/pkg/apis/core",
     "k8s.io/kubernetes/pkg/apis/core/pods",
     "k8s.io/kubernetes/pkg/fieldpath",
     "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2",

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -44,9 +44,9 @@ func loadTLSConfig(certPath, keyPath string) (*tls.Config, error) {
 	}, nil
 }
 
-func setupHTTPServer(ctx context.Context, cfg *apiServerConfig) (cancel func(), retErr error) {
+func setupHTTPServer(ctx context.Context, cfg *apiServerConfig) (_ func(), retErr error) {
 	var closers []io.Closer
-	cancel = func() {
+	cancel := func() {
 		for _, c := range closers {
 			c.Close()
 		}


### PR DESCRIPTION
Exec seems to be broken by ad6fbba806a9470fc6d3feef636ee339632c4ab8
This change basically copies what's in remotecommand.NewOptions, just
without the logging.

(cherry picked from commit 449eb3bb7d93dbc71c1f52f48a7de6f049c76074)