### PR TITLE
Add timeout to e2e tests

### DIFF
--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -39,7 +39,7 @@ e2e: TAINT_EFFECT := NoSchedule
 e2e: export VK_BUILD_TAGS += mock_provider
 e2e: e2e.clean bin/e2e/virtual-kubelet skaffold/run
 	@echo Running tests...
-	cd $(PWD)/test/e2e && go test -v -tags e2e ./... \
+	cd $(PWD)/test/e2e && go test -v -timeout 5m -tags e2e ./... \
 		-kubeconfig=$(KUBECONFIG) \
 		-namespace=$(NAMESPACE) \
 		-node-name=$(NODE_NAME) \


### PR DESCRIPTION
This adds a 5 minute timeout to the end-to-end tests. The end-to-end
tests typically run in under 2 minutes. On Circle-CI the timeout is
10 minutes, at which point, Circle CI just shoots the tests in the
head so we don't get any logs.