### PR TITLE
Remove setting taint during e2e test

### DIFF
--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -33,9 +33,6 @@ bin/e2e/virtual-kubelet: bin/e2e
 e2e: KUBECONFIG ?= $(HOME)/.kube/config
 e2e: NAMESPACE := default
 e2e: NODE_NAME := vkubelet-mock-0
-e2e: TAINT_KEY := virtual-kubelet.io/provider
-e2e: TAINT_VALUE := mock
-e2e: TAINT_EFFECT := NoSchedule
 e2e: export VK_BUILD_TAGS += mock_provider
 e2e: e2e.clean bin/e2e/virtual-kubelet skaffold/run
 	@echo Running tests...
@@ -43,9 +40,6 @@ e2e: e2e.clean bin/e2e/virtual-kubelet skaffold/run
 		-kubeconfig=$(KUBECONFIG) \
 		-namespace=$(NAMESPACE) \
 		-node-name=$(NODE_NAME) \
-		-taint-key=$(TAINT_KEY) \
-		-taint-value=$(TAINT_VALUE) \
-		-taint-effect=$(TAINT_EFFECT)
 
 .PHONY: e2e.clean
 e2e.clean: NODE_NAME ?= vkubelet-mock-0

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -8,23 +8,17 @@ import (
 
 // Framework encapsulates the configuration for the current run, and provides helper methods to be used during testing.
 type Framework struct {
-	KubeClient  kubernetes.Interface
-	Namespace   string
-	NodeName    string
-	TaintKey    string
-	TaintValue  string
-	TaintEffect string
+	KubeClient kubernetes.Interface
+	Namespace  string
+	NodeName   string
 }
 
 // NewTestingFramework returns a new instance of the testing framework.
-func NewTestingFramework(kubeconfig, namespace, nodeName, taintKey, taintValue, taintEffect string) *Framework {
+func NewTestingFramework(kubeconfig, namespace, nodeName string) *Framework {
 	return &Framework{
-		KubeClient:  createKubeClient(kubeconfig),
-		Namespace:   namespace,
-		NodeName:    nodeName,
-		TaintKey:    taintKey,
-		TaintValue:  taintValue,
-		TaintEffect: taintEffect,
+		KubeClient: createKubeClient(kubeconfig),
+		Namespace:  namespace,
+		NodeName:   nodeName,
 	}
 }
 

--- a/test/e2e/framework/pod.go
+++ b/test/e2e/framework/pod.go
@@ -15,10 +15,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 )
 
-const (
-	defaultWatchTimeout       = 2 * time.Minute
-	hostnameNodeSelectorLabel = "kubernetes.io/hostname"
-)
+const defaultWatchTimeout = 2 * time.Minute
 
 // CreateDummyPodObjectWithPrefix creates a dujmmy pod object using the specified prefix as the value of .metadata.generateName.
 // A variable number of strings can be provided.
@@ -33,16 +30,7 @@ func (f *Framework) CreateDummyPodObjectWithPrefix(prefix string, images ...stri
 			Namespace:    f.Namespace,
 		},
 		Spec: corev1.PodSpec{
-			NodeSelector: map[string]string{
-				hostnameNodeSelectorLabel: f.NodeName,
-			},
-			Tolerations: []corev1.Toleration{
-				{
-					Key:    f.TaintKey,
-					Value:  f.TaintValue,
-					Effect: corev1.TaintEffect(f.TaintEffect),
-				},
-			},
+			NodeName:           f.NodeName,
 			EnableServiceLinks: &enableServiceLink,
 		},
 	}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -13,11 +13,8 @@ import (
 )
 
 const (
-	defaultNamespace   = v1.NamespaceDefault
-	defaultNodeName    = "vkubelet-mock-0"
-	defaultTaintKey    = "virtual-kubelet.io/provider"
-	defaultTaintValue  = "mock"
-	defaultTaintEffect = string(v1.TaintEffectNoSchedule)
+	defaultNamespace = v1.NamespaceDefault
+	defaultNodeName  = "vkubelet-mock-0"
 )
 
 var (
@@ -30,21 +27,12 @@ var (
 	namespace string
 	// nodeName is the name of the virtual-kubelet node to test.
 	nodeName string
-	// taintKey is the key of the taint that is expected to be associated with the virtual-kubelet node to test.
-	taintKey string
-	// taintValue is the value of the taint that is expected to be associated with the virtual-kubelet node to test.
-	taintValue string
-	// taintEffect is the effect of the taint that is expected to be associated with the virtual-kubelet node to test.
-	taintEffect string
 )
 
 func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "path to the kubeconfig file to use when running the test suite outside a kubernetes cluster")
 	flag.StringVar(&namespace, "namespace", defaultNamespace, "the name of the kubernetes namespace to use for running the test suite (i.e. where to create pods)")
 	flag.StringVar(&nodeName, "node-name", defaultNodeName, "the name of the virtual-kubelet node to test")
-	flag.StringVar(&taintKey, "taint-key", defaultTaintKey, "the key of the taint that is expected to be associated with the virtual-kubelet node to test")
-	flag.StringVar(&taintValue, "taint-value", defaultTaintValue, "the value of the taint that is expected to be associated with the virtual-kubelet node to test")
-	flag.StringVar(&taintEffect, "taint-effect", defaultTaintEffect, "the effect of the taint that is expected to be associated with the virtual-kubelet node to test")
 	flag.Parse()
 }
 
@@ -52,7 +40,7 @@ func TestMain(m *testing.M) {
 	// Set sane defaults in case no values (or empty ones) have been provided.
 	setDefaults()
 	// Create a new instance of the test framework targeting the specified node.
-	f = framework.NewTestingFramework(kubeconfig, namespace, nodeName, taintKey, taintValue, taintEffect)
+	f = framework.NewTestingFramework(kubeconfig, namespace, nodeName)
 	// Wait for the virtual-kubelet pod to be ready.
 	if err := f.WaitUntilPodReady(namespace, nodeName); err != nil {
 		panic(err)
@@ -68,14 +56,5 @@ func setDefaults() {
 	}
 	if nodeName == "" {
 		nodeName = defaultNodeName
-	}
-	if taintKey == "" {
-		taintKey = defaultTaintKey
-	}
-	if taintValue == "" {
-		taintValue = defaultTaintValue
-	}
-	if taintEffect == "" {
-		taintEffect = defaultTaintEffect
 	}
 }


### PR DESCRIPTION
We're in effect testing the K8s scheduler logic in the test
by setting taints, as opposed to the actual VK itself. If we
want to make sure the taint is set, we can just observe the node
object.

Instead, bind to the pod to the VK node explicitly.