### PR TITLE
Handle not found case for status update

### DIFF
--- a/vkubelet/queue.go
+++ b/vkubelet/queue.go
@@ -55,7 +55,7 @@ func handleQueueItem(ctx context.Context, q workqueue.RateLimitingInterface, han
 		if err := handler(ctx, key); err != nil {
 			if q.NumRequeues(key) < maxRetries {
 				// Put the item back on the work queue to handle any transient errors.
-				log.G(ctx).Warnf("requeuing %q due to failed sync: %v", key, err)
+				log.G(ctx).WithError(err).Warnf("requeuing %q due to failed sync", key)
 				q.AddRateLimited(key)
 				return nil
 			}


### PR DESCRIPTION
If we don't handle the "pod not found" case then we end up with the pod
getting re-queued over and over until the max retries are hit. It also
blocks the queue for other pod status updates for that pod
namespace/name.