### PR TITLE
Bugfix: Azure ACI provider memory limits round

### DIFF
--- a/providers/azure/aci.go
+++ b/providers/azure/aci.go
@@ -1220,11 +1220,11 @@ func (p *ACIProvider) getContainers(pod *v1.Pod) ([]aci.Container, error) {
 				cpuLimit = float64(container.Resources.Limits.Cpu().MilliValue()) / 1000.00
 			}
 
+			// NOTE(jahstreet): ACI memory limit must be times of 0.1 GB
 			memoryLimit := memoryRequest
 			if _, ok := container.Resources.Limits[v1.ResourceMemory]; ok {
-				memoryLimit = float64(container.Resources.Limits.Memory().Value()) / 1000000000.00
+				memoryLimit = float64(container.Resources.Limits.Memory().Value()/100000000.00) / 10.00
 			}
-
 			c.Resources.Limits = &aci.ComputeResources{
 				CPU:        cpuLimit,
 				MemoryInGB: memoryLimit,

--- a/providers/azure/aci_test.go
+++ b/providers/azure/aci_test.go
@@ -383,7 +383,7 @@ func TestCreatePodWithResourceRequestAndLimit(t *testing.T) {
 		assert.Check(t, is.Equal(1.98, cg.ContainerGroupProperties.Containers[0].Resources.Requests.CPU), "Request CPU is not expected")
 		assert.Check(t, is.Equal(3.4, cg.ContainerGroupProperties.Containers[0].Resources.Requests.MemoryInGB), "Request Memory is not expected")
 		assert.Check(t, is.Equal(3.999, cg.ContainerGroupProperties.Containers[0].Resources.Limits.CPU), "Limit CPU is not expected")
-		assert.Check(t, is.Equal(8.01, cg.ContainerGroupProperties.Containers[0].Resources.Limits.MemoryInGB), "Limit Memory is not expected")
+		assert.Check(t, is.Equal(8.0, cg.ContainerGroupProperties.Containers[0].Resources.Limits.MemoryInGB), "Limit Memory is not expected")
 
 		return http.StatusOK, cg
 	}


### PR DESCRIPTION
Description:
Azure ACI memory limits have to be of a multiplier of 0.1G, just like for memory requests. I propose to calculate memory limits like we do it for memory requests.

This PR fixes errors when user sets memory limits to a specific value which is not a multiplier of 0.1G and allows user to set memory limits in power-of-two format, eg: Mi, Gi, etc.

A point to discuss here maybe and idea to ceil (round up) memory requests and limits to the 0.1G multiplied value. At present those values are rounded down which causes to create a Container in ACI with a memory value lower then user may want to request.

Signed-off-by: Aliaksandr Sasnouskikh <jahstreetlove@gmail.com>