### PR TITLE
Bugfix: Azure ACI provider skips ConfigMap Data exctraction on volumes mapping

### DIFF
--- a/providers/azure/aci.go
+++ b/providers/azure/aci.go
@@ -1430,6 +1430,9 @@ func (p *ACIProvider) getVolumes(pod *v1.Pod) ([]aci.Volume, error) {
 				continue
 			}
 
+			for k, v := range configMap.Data {
+				paths[k] = base64.StdEncoding.EncodeToString([]byte(v))
+			}
 			for k, v := range configMap.BinaryData {
 				paths[k] = base64.StdEncoding.EncodeToString(v)
 			}


### PR DESCRIPTION
Description:
Azure ACI provider extracts only BinaryData from ConfigMap and skips extracting Data, while getting volumes from Pod Spec. This causes to skip that volume, though it still exists in volume mounts.

This PR adds a step to extract ConfigMap Data when building ACI volume from ConfigMap.

Related issues:
- https://github.com/virtual-kubelet/virtual-kubelet/issues/441
- https://github.com/virtual-kubelet/virtual-kubelet/issues/523

Signed-off-by: Aliaksandr Sasnouskikh <jahstreetlove@gmail.com>