### PR TITLE
Allow virtual-kubelet to use cluster domain

### DIFF
--- a/cmd/virtual-kubelet/commands/root/flag.go
+++ b/cmd/virtual-kubelet/commands/root/flag.go
@@ -60,6 +60,7 @@ func (mv mapVar) Type() string {
 func installFlags(flags *pflag.FlagSet, c *Opts) {
 	flags.StringVar(&c.KubeConfigPath, "kubeconfig", c.KubeConfigPath, "kube config file to use for connecting to the Kubernetes API server")
 	flags.StringVar(&c.KubeNamespace, "namespace", c.KubeNamespace, "kubernetes namespace (default is 'all')")
+	flags.StringVar(&c.KubeClusterDomain, "cluster-domain", c.KubeClusterDomain, "kubernetes cluster-domain (default is 'cluster.local')")
 	flags.StringVar(&c.NodeName, "nodename", c.NodeName, "kubernetes node name")
 	flags.StringVar(&c.OperatingSystem, "os", c.OperatingSystem, "Operating System (Linux/Windows)")
 	flags.StringVar(&c.Provider, "provider", c.Provider, "cloud provider")

--- a/cmd/virtual-kubelet/commands/root/opts.go
+++ b/cmd/virtual-kubelet/commands/root/opts.go
@@ -34,6 +34,7 @@ const (
 	DefaultListenPort           = 10250 // TODO(cpuguy83)(VK1.0): Change this to an addr instead of just a port.. we should not be listening on all interfaces.
 	DefaultPodSyncWorkers       = 10
 	DefaultKubeNamespace        = corev1.NamespaceAll
+	DefaultKubeClusterDomain    = "cluster.local"
 
 	DefaultTaintEffect = string(corev1.TaintEffectNoSchedule)
 	DefaultTaintKey    = "virtual-kubelet.io/provider"
@@ -49,6 +50,9 @@ type Opts struct {
 	KubeConfigPath string
 	// Namespace to watch for pods and other resources
 	KubeNamespace string
+	// Domain suffix to append to search domains for the pods created by virtual-kubelet
+	KubeClusterDomain string
+
 	// Sets the port to listen for requests from the Kubernetes API server
 	ListenPort int32
 
@@ -125,6 +129,10 @@ func SetDefaultOpts(c *Opts) error {
 
 	if c.KubeNamespace == "" {
 		c.KubeNamespace = DefaultKubeNamespace
+	}
+
+	if c.KubeClusterDomain == "" {
+		c.KubeClusterDomain = DefaultKubeClusterDomain
 	}
 
 	if c.TaintKey == "" {

--- a/cmd/virtual-kubelet/commands/root/root.go
+++ b/cmd/virtual-kubelet/commands/root/root.go
@@ -126,6 +126,7 @@ func runRootCommand(ctx context.Context, s *providers.Store, c Opts) error {
 		ResourceManager: rm,
 		DaemonPort:      int32(c.ListenPort),
 		InternalIP:      os.Getenv("VKUBELET_POD_IP"),
+		KubeClusterDomain: c.KubeClusterDomain,
 	}
 
 	pInit := s.Get(c.Provider)

--- a/providers/store.go
+++ b/providers/store.go
@@ -62,12 +62,13 @@ func (s *Store) Exists(name string) bool {
 
 // InitConfig is the config passed to initialize a registered provider.
 type InitConfig struct {
-	ConfigPath      string
-	NodeName        string
-	OperatingSystem string
-	InternalIP      string
-	DaemonPort      int32
-	ResourceManager *manager.ResourceManager
+	ConfigPath        string
+	NodeName          string
+	OperatingSystem   string
+	InternalIP        string
+	DaemonPort        int32
+	KubeClusterDomain string
+	ResourceManager   *manager.ResourceManager
 }
 
 type InitFunc func(InitConfig) (Provider, error)


### PR DESCRIPTION
This allows `--cluster-domain` to be passed to virtual kubelet like a
traditional kublet, and use this to generate search-domains for
`/etc/resolv.conf`

* Set default `cluster-domain` to `cluster-local` to match current kubelet
* Added an example usage for the Azure provider
* * Only apply to pods with `DNSClusterFirst` to match kubelet
* * Merge search-domains with any set in the `dnsConfig`
* * Set `ndots` to the default 5

Related: #641

Signed-off-by: Graham Hayes <gr@ham.ie>