### PR TITLE
Delete virtual node when virtual kubelet is removed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ loganalytics.json
 # VS Code files
 .vscode/
 
+# IntelliJ Goland files
+.idea
+
 # Terraform ignores
 **/.terraform/**
 **/terraform-provider-kubernetes

--- a/vkubelet/node.go
+++ b/vkubelet/node.go
@@ -233,7 +233,7 @@ func (n *Node) controlLoop(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return n.nodes.Delete(n.n.Name, &metav1.DeleteOptions{})
 		case updated := <-n.chStatusUpdate:
 			var t *time.Timer
 			if n.disableLease {


### PR DESCRIPTION
Right now when virtual kubelet pod is removed, virtual node is transitioned in a state `NotReady` and remains in k8s node list. This PR fixes that.