### PR TITLE
Remove resourcemanager from conroller public API

### DIFF
--- a/cmd/virtual-kubelet/commands/root/root.go
+++ b/cmd/virtual-kubelet/commands/root/root.go
@@ -181,7 +181,9 @@ func runRootCommand(ctx context.Context, c Opts) error {
 		PodInformer:     podInformer,
 		EventRecorder:   eb.NewRecorder(scheme.Scheme, corev1.EventSource{Component: path.Join(pNode.Name, "pod-controller")}),
 		Provider:        p,
-		ResourceManager: rm,
+		SecretLister:    secretInformer.Lister(),
+		ConfigMapLister: configMapInformer.Lister(),
+		ServiceLister:   serviceInformer.Lister(),
 	})
 	if err != nil {
 		return errors.Wrap(err, "error setting up pod controller")


### PR DESCRIPTION
We still use it internally, but this does not need to be part of the
public API. Instead just have callers pass us the relevent listers and
we create our own resource manager.