### PR TITLE
Allow Annotations to be set on nodes derived from a Provider

### DIFF
--- a/cmd/virtual-kubelet/commands/root/node.go
+++ b/cmd/virtual-kubelet/commands/root/node.go
@@ -44,6 +44,7 @@ func NodeFromProvider(ctx context.Context, name string, taint *v1.Taint, p provi
 				"kubernetes.io/hostname": name,
 				"alpha.service-controller.kubernetes.io/exclude-balancer": "true",
 			},
+			Annotations: p.NodeAnnotations(ctx),
 		},
 		Spec: v1.NodeSpec{
 			Taints: taints,

--- a/cmd/virtual-kubelet/commands/root/root.go
+++ b/cmd/virtual-kubelet/commands/root/root.go
@@ -120,12 +120,12 @@ func runRootCommand(ctx context.Context, s *providers.Store, c Opts) error {
 	}
 
 	initConfig := providers.InitConfig{
-		ConfigPath:      c.ProviderConfigPath,
-		NodeName:        c.NodeName,
-		OperatingSystem: c.OperatingSystem,
-		ResourceManager: rm,
-		DaemonPort:      int32(c.ListenPort),
-		InternalIP:      os.Getenv("VKUBELET_POD_IP"),
+		ConfigPath:        c.ProviderConfigPath,
+		NodeName:          c.NodeName,
+		OperatingSystem:   c.OperatingSystem,
+		ResourceManager:   rm,
+		DaemonPort:        int32(c.ListenPort),
+		InternalIP:        os.Getenv("VKUBELET_POD_IP"),
 		KubeClusterDomain: c.KubeClusterDomain,
 	}
 

--- a/providers/mock/mock_test.go
+++ b/providers/mock/mock_test.go
@@ -1,12 +1,43 @@
 package mock
 
-// We can guarantee the right interfaces are implemented inside of by putting casts in place. We must do the verification
-// that a given type *does not* implement a given interface in this test.
-// Cannot implement this due to:  https://github.com/virtual-kubelet/virtual-kubelet/issues/632
-/*
-func TestMockLegacyInterface(t *testing.T) {
-	var mlp providers.Provider = &MockLegacyProvider{}
-	_, ok := mlp.(node.PodNotifier)
-	assert.Assert(t, !ok)
+import (
+	"context"
+	"github.com/virtual-kubelet/virtual-kubelet/cmd/virtual-kubelet/commands/root"
+	"gotest.tools/assert"
+	"testing"
+)
+
+// Determine that annotations from the Provider are respected when constructing the Node
+func TestNodeFromMockProvider(t *testing.T) {
+	const (
+		NodeName           = "nodeName"
+		OperatingSystem    = "os"
+		InternalIp         = "1.2.3.4"
+		DaemonEndpointPort = 42
+		Version            = "v0.1"
+	)
+
+	expectedAnnotations := map[string]string{
+		"Key": "Value",
+	}
+
+	ctx := context.TODO()
+
+	// Empty config
+	mockConfig := MockConfig{}
+	mockProvider, err := NewMockProviderMockConfig(mockConfig, NodeName, OperatingSystem, InternalIp, DaemonEndpointPort)
+	assert.NilError(t, err)
+
+	node := root.NodeFromProvider(ctx, NodeName, nil, mockProvider, Version)
+	assert.Equal(t, 0, len(node.Annotations))
+
+	// Annotated config
+	mockConfig = MockConfig{
+		Annotations: expectedAnnotations,
+	}
+	mockProvider, err = NewMockProviderMockConfig(mockConfig, NodeName, OperatingSystem, InternalIp, DaemonEndpointPort)
+	assert.NilError(t, err)
+
+	node = root.NodeFromProvider(ctx, NodeName, nil, mockProvider, Version)
+	assert.DeepEqual(t, expectedAnnotations, node.Annotations)
 }
-*/

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -40,6 +40,9 @@ type Provider interface {
 	// within Kubernetes.
 	NodeDaemonEndpoints(context.Context) *v1.NodeDaemonEndpoints
 
+	// NodeAnnotations returns the Annotations for node metadata within Kubernetes.
+	NodeAnnotations(context.Context) map[string]string
+
 	// OperatingSystem returns the operating system the provider is for.
 	OperatingSystem() string
 }


### PR DESCRIPTION
Today the following fields on the Node are derived from the Provider.
```
NodeStatus:
    Capacity,
    Allocatable,
    Conditions,
    Addresses,
    DaemonEndpoints,
```
```
ObjectMetadata:
    Labels:
        beta.kubernets.io/os,
```

Here we extend this list to also set:
```
ObjectMetadata:
    Annotations,
```