### PR TITLE
Fix links to provider docs on the website

### DIFF
--- a/website/data/providers.yaml
+++ b/website/data/providers.yaml
@@ -1,16 +1,16 @@
 - name: Alibaba Cloud Elastic Container Instance (**ECI**)
-  tag: alibabacloud
+  tag: alibabacloud-eci
 - name: AWS Fargate
-  tag: aws
+  tag: aws-fargate
 - name: Azure Batch
-  tag: azurebatch
+  tag: azure-batch
 - name: Azure Container Instances (**ACI**)
-  tag: azure
+  tag: azure-aci
 - name: Kubernetes Container Runtime Interface (**CRI**)
   tag: cri
 - name: Huawei Cloud Container Instance (**CCI**)
-  tag: huawei
+  tag: huawei-cci
 - name: HashiCorp Nomad
   tag: nomad
 - name: OpenStack Zun
-  tag: openstack
+  tag: openstack-zun

--- a/website/layouts/partials/home/info.html
+++ b/website/layouts/partials/home/info.html
@@ -25,7 +25,7 @@
 
         <ul>
           {{ range $providers }}
-          {{ $url := printf "https://github.com/virtual-kubelet/virtual-kubelet/tree/master/providers/%s" .tag }}
+          {{ $url := printf "https://github.com/virtual-kubelet/%s/blob/master/README.md#readme" .tag }}
           <li class="has-bottom-spacing">
             <a class="is-size-5 is-size-6-mobile has-text-grey-lighter has-text-weight-light" href="{{ $url }}" target="_blank">
               {{ .name | markdownify }}

--- a/website/layouts/shortcodes/providers.html
+++ b/website/layouts/shortcodes/providers.html
@@ -3,8 +3,8 @@
   <tbody>
     {{ range $providers }}
     {{ $name     := .name | markdownify }}
-    {{ $pkgName  := printf "github.com/virtual-kubelet/virtual-kubelet/providers/%s" .tag }}
-    {{ $pkgUrl   := printf "https://github.com/virtual-kubelet/virtual-kubelet/tree/master/providers/%s" .tag }}
+    {{ $pkgName  := printf "github.com/virtual-kubelet/%s" .tag }}
+    {{ $pkgUrl   := printf "https://github.com/virtual-kubelet/%s/blob/master/README.md#readme" .tag }}
     {{ $godocUrl := printf "https://godoc.org/%s" $pkgName }}
     <tr>
       <td>


### PR DESCRIPTION
On https://virtual-kubelet.io/ and https://virtual-kubelet.io/docs/#providers the links to providers documentations are incorrect. Providers moved to dedicated repositories.

Example : 
https://github.com/virtual-kubelet/virtual-kubelet/tree/master/providers/aws has been replaced by https://github.com/virtual-kubelet/aws-fargate/blob/master/README.md#readme