### PR TITLE
Fix error handling for delete pod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,11 +83,9 @@ else
 endif
 
 test:
-	@echo "Testing..."
-	$Q go test -mod=vendor $(if $V,-v) $(allpackages) # install -race libs to speed up next run
 ifndef CI
-	@echo "Testing Outside CI..."
-	$Q GODEBUG=cgocheck=2 go test -mod=vendor $(allpackages)
+	@echo "Testing..."
+	$Q go test -mod=vendor $(if $V,-v) $(allpackages)
 else
 	@echo "Testing in CI..."
 	$Q mkdir -p test


### PR DESCRIPTION
    - Error handling was looking for a k8s error from the provider, but
      providers should be using errdefs.
    - Error handling was returning early if pod was not found and deleting
      from k8s in all other cases.

Fixes #521