### PR TITLE
Add "TerminatePod" to lifecycle interface

### DIFF
--- a/internal/test/e2e/framework/pod.go
+++ b/internal/test/e2e/framework/pod.go
@@ -113,7 +113,7 @@ func (f *Framework) WaitUntilPodReady(namespace, name string) (*corev1.Pod, erro
 func (f *Framework) WaitUntilPodDeleted(namespace, name string) (*corev1.Pod, error) {
 	return f.WaitUntilPodCondition(namespace, name, func(event watchapi.Event) (bool, error) {
 		pod := event.Object.(*corev1.Pod)
-		return event.Type == watchapi.Deleted || pod.ObjectMeta.DeletionTimestamp != nil, nil
+		return event.Type == watchapi.Deleted || (pod.ObjectMeta.DeletionTimestamp != nil && pod.Status.Phase != corev1.PodRunning), nil
 	})
 }
 

--- a/node/pod_test.go
+++ b/node/pod_test.go
@@ -33,9 +33,10 @@ import (
 type mockProvider struct {
 	pods map[string]*corev1.Pod
 
-	creates int
-	updates int
-	deletes int
+	creates    int
+	updates    int
+	terminates int
+	deletes    int
 
 	errorOnDelete error
 }
@@ -66,6 +67,16 @@ func (m *mockProvider) GetPodStatus(ctx context.Context, namespace, name string)
 		return nil, errdefs.NotFound("not found")
 	}
 	return &p.Status, nil
+}
+
+func (m *mockProvider) TerminatePod(ctx context.Context, p *corev1.Pod) error {
+	p = m.pods[path.Join(p.Namespace, p.Name)]
+	if p == nil {
+		return errdefs.NotFound("not found")
+	}
+	p.Status.Phase = corev1.PodSucceeded
+	m.terminates++
+	return nil
 }
 
 func (m *mockProvider) DeletePod(ctx context.Context, p *corev1.Pod) error {


### PR DESCRIPTION
This splits the termination of a pod from the deletion of it.
It allows providers to update the final pod status before deleting it is
deleted form k8s.

Pod is terminated if pod.Phase == Running and pod.DeletionTimestamp is
not nil.

When the provider is ready for the pod to be deleted, the pod status
should be udpated so it's not "Running", but whatever is appropriate for
the exist statuses of the containers.
Once the status is updated a new event will be triggered from k8s which
will trigger us to call `DeletePod` as before.