### PR TITLE
node: set label to enable selection

### DIFF
--- a/cmd/virtual-kubelet/internal/commands/root/node.go
+++ b/cmd/virtual-kubelet/internal/commands/root/node.go
@@ -21,7 +21,7 @@ import (
 	"github.com/virtual-kubelet/virtual-kubelet/cmd/virtual-kubelet/internal/provider"
 	"github.com/virtual-kubelet/virtual-kubelet/errdefs"
 	nodehelper "github.com/virtual-kubelet/virtual-kubelet/node"
-	
+
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/cmd/virtual-kubelet/internal/commands/root/root.go
+++ b/cmd/virtual-kubelet/internal/commands/root/root.go
@@ -27,6 +27,7 @@ import (
 	"github.com/virtual-kubelet/virtual-kubelet/internal/manager"
 	"github.com/virtual-kubelet/virtual-kubelet/log"
 	"github.com/virtual-kubelet/virtual-kubelet/node"
+
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/node/node.go
+++ b/node/node.go
@@ -190,7 +190,8 @@ type ErrorHandler func(context.Context, error) error
 // NodeController deals with creating and managing a node object in Kubernetes.
 // It can register a node with Kubernetes and periodically update its status.
 // NodeController manages a single node entity.
-type NodeController struct { // nolint: golint
+type NodeController struct {
+	// nolint: golint
 	p NodeProvider
 	n *corev1.Node
 
@@ -217,7 +218,7 @@ const (
 // Run registers the node in kubernetes and starts loops for updating the node
 // status in Kubernetes.
 //
-// The node status must be updated periodically in Kubertnetes to keep the node
+// The node status must be updated periodically in Kubernetes to keep the node
 // active. Newer versions of Kubernetes support node leases, which are
 // essentially light weight pings. Older versions of Kubernetes require updating
 // the node status periodically.

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -25,7 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	watch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apimachinery/pkg/watch"
 	testclient "k8s.io/client-go/kubernetes/fake"
 )
 


### PR DESCRIPTION
By setting Node resource label `beta.kubernetes.io/instance-type` to `virtual-kubelet`, we are enabling controllers to filter nodes that are virtual-kubelet instances.
Two examples of controllers that may benefit from this are:
- cloud-controller-manager node controller, which deletes Node resources that
are not present in the cloud-provider;
- cluster-autoscaler, which scales up/down worker machines to satisfy a
Kubernetes cluster needs.

Fixes #692