### PR TITLE
skaffold target requires .SECONDEXPANSION

### DIFF
--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -11,7 +11,8 @@ skaffold.validate:
 # MODE must be set to one of "dev" (default), "delete" or "run", and is used as the skaffold command to be run.
 .PHONY: skaffold
 skaffold: MODE ?= dev
-skaffold: skaffold/$(MODE)
+.SECONDEXPANSION:
+skaffold: skaffold/$$(MODE)
 
 .PHONY: skaffold/%
 skaffold/%: PROFILE := local
@@ -19,6 +20,8 @@ skaffold/%: skaffold.validate
 	skaffold $(*) \
 		-f $(PWD)/hack/skaffold/virtual-kubelet/skaffold.yml \
 		-p $(PROFILE)
+
+skaffold/run skaffold/dev: bin/e2e/virtual-kubelet
 
 bin/e2e:
 	@mkdir -p bin/e2e


### PR DESCRIPTION
Otherwise the variable is evaluated before it's even set (assuming it's
not set from the CLI).

skaffold also requires bin/e2e/virtual-kubelet to work on it's own.

Fixes #693 