### PR TITLE
Make NewPodController function validate that provider is set

### DIFF
--- a/node/podcontroller.go
+++ b/node/podcontroller.go
@@ -138,6 +138,9 @@ func NewPodController(cfg PodControllerConfig) (*PodController, error) {
 	if cfg.ServiceInformer == nil {
 		return nil, errdefs.InvalidInput("missing service informer")
 	}
+	if cfg.Provider == nil {
+		return nil, errdefs.InvalidInput("missing provider")
+	}
 
 	rm, err := manager.NewResourceManager(cfg.PodInformer.Lister(), cfg.SecretInformer.Lister(), cfg.ConfigMapInformer.Lister(), cfg.ServiceInformer.Lister())
 	if err != nil {


### PR DESCRIPTION
In NewPodController we validate that the rest of the config is
set to non-nil values. The provider must be non-nil as well.