### PR TITLE
Add a little bit of documentation to NotifyPods

### DIFF
--- a/node/podcontroller.go
+++ b/node/podcontroller.go
@@ -69,9 +69,13 @@ type PodLifecycleHandler interface {
 // of pod status updates asynchronously.
 type PodNotifier interface {
 	// NotifyPods instructs the notifier to call the passed in function when
-	// the pod status changes.
+	// the pod status changes. It should be called when a pod's status changes.
 	//
-	// NotifyPods should not block callers.
+	// The provided pointer to a Pod is guaranteed to be used in a read-only
+	// fashion. The provided pod's PodStatus should be up to date when
+	// this function is called.
+	//
+	// NotifyPods will not block callers.
 	NotifyPods(context.Context, func(*corev1.Pod))
 }
 


### PR DESCRIPTION
As far as I can tell, based on the implementation in MockProvider
NotifyPods is called with the mutated pod. This allows us to
take a copy of the Pod object in NotifyPods, and make it so
(eventually) we don't need to do a callback to GetPodStatus.