### PR TITLE
Introduce PodLifecycleHandlerV0 interface

### DIFF
--- a/node/legacy_wrapper.go
+++ b/node/legacy_wrapper.go
@@ -1,0 +1,79 @@
+package node
+
+import (
+	"context"
+	"time"
+
+	pkgerrors "github.com/pkg/errors"
+	"github.com/virtual-kubelet/virtual-kubelet/log"
+	"github.com/virtual-kubelet/virtual-kubelet/trace"
+	v1 "k8s.io/api/core/v1"
+)
+
+type legacyPodLifecycleHandlerWrapper struct {
+	PodLifecycleHandlerV0
+	notifier      func(*v1.Pod)
+	reconcileTime time.Duration
+}
+
+func (wrapper *legacyPodLifecycleHandlerWrapper) NotifyPods(ctx context.Context, notifier func(*v1.Pod)) {
+	wrapper.notifier = notifier
+}
+
+// updatePodStatuses syncs the providers pod status with the kubernetes pod status.
+func (wrapper *legacyPodLifecycleHandlerWrapper) updatePodStatuses(ctx context.Context) {
+	ctx, span := trace.StartSpan(ctx, "updatePodStatuses")
+	defer span.End()
+
+	pods, err := wrapper.GetPods(ctx)
+	if err != nil {
+		err = pkgerrors.Wrap(err, "error getting pod list")
+		span.SetStatus(err)
+		log.G(ctx).WithError(err).Error("Error updating pod statuses")
+		return
+	}
+
+	for _, pod := range pods {
+		// Notifier is idempotent.
+		wrapper.notifier(pod)
+	}
+}
+
+func (wrapper *legacyPodLifecycleHandlerWrapper) run(ctx context.Context) {
+	for {
+		t := time.NewTimer(wrapper.reconcileTime)
+		defer t.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				t.Stop()
+
+				ctx, span := trace.StartSpan(ctx, "syncActualState")
+				wrapper.updatePodStatuses(ctx)
+				span.End()
+
+				// restart the timer
+				t.Reset(wrapper.reconcileTime)
+			}
+		}
+	}
+}
+
+type WrappedPodLifecycleHandler interface {
+	PodLifecycleHandler
+	run(ctx context.Context)
+}
+
+// WrapLegacyPodLifecycleHandler allows you to use a LegacyPodLifecycleHandler. It runs a background loop, based on
+// reconcileTime. Every period it will call GetPods.
+func WrapLegacyPodLifecycleHandler(ctx context.Context, handler PodLifecycleHandlerV0, reconcileTime time.Duration) WrappedPodLifecycleHandler {
+	wrapper := &legacyPodLifecycleHandlerWrapper{
+		PodLifecycleHandlerV0: handler,
+		reconcileTime:         reconcileTime,
+	}
+
+	return wrapper
+}

--- a/node/mock_test.go
+++ b/node/mock_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	_ PodLifecycleHandler = (*mockV0Provider)(nil)
-	_ PodNotifier         = (*mockProvider)(nil)
+	_ PodLifecycleHandlerV0 = (*mockV0Provider)(nil)
+	_ PodLifecycleHandler   = (*mockProvider)(nil)
 )
 
 type mockV0Provider struct {

--- a/node/podcontroller.go
+++ b/node/podcontroller.go
@@ -38,13 +38,17 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
-// PodLifecycleHandler defines the interface used by the PodController to react
-// to new and changed pods scheduled to the node that is being managed.
+const (
+	DefaultWrapLegacyPodLifecycleHandlerLoopTime = 5 * time.Second
+)
+
+// PodLifecycleHandlerV0 defines the interface used by the PodController
+// to react to new and changed pods scheduled to the node that is being managed.
 //
 // Errors produced by these methods should implement an interface from
 // github.com/virtual-kubelet/virtual-kubelet/errdefs package in order for the
 // core logic to be able to understand the type of failure.
-type PodLifecycleHandler interface {
+type PodLifecycleHandlerV0 interface {
 	// CreatePod takes a Kubernetes Pod and deploys it within the provider.
 	CreatePod(ctx context.Context, pod *corev1.Pod) error
 
@@ -54,22 +58,28 @@ type PodLifecycleHandler interface {
 	// DeletePod takes a Kubernetes Pod and deletes it from the provider.
 	DeletePod(ctx context.Context, pod *corev1.Pod) error
 
-	// GetPod retrieves a pod by name from the provider (can be cached).
+	// GetPod retrieves a pod by name from the provider
 	GetPod(ctx context.Context, namespace, name string) (*corev1.Pod, error)
 
 	// GetPodStatus retrieves the status of a pod by name from the provider.
 	GetPodStatus(ctx context.Context, namespace, name string) (*corev1.PodStatus, error)
 
-	// GetPods retrieves a list of all pods running on the provider (can be cached).
+	// GetPods retrieves a list of all pods running on the provider
 	GetPods(context.Context) ([]*corev1.Pod, error)
 }
 
-// PodNotifier notifies callers of pod changes.
-// Providers should implement this interface to enable callers to be notified
-// of pod status updates asynchronously.
-type PodNotifier interface {
+// PodLifecycleHandler defines the interface used by the PodController
+// to react to new and changed pods scheduled to the node that is being managed.
+//
+// Errors produced by these methods should implement an interface from
+// github.com/virtual-kubelet/virtual-kubelet/errdefs package in order for the
+// core logic to be able to understand the type of failure.
+type PodLifecycleHandler interface {
+	PodLifecycleHandlerV0
+
 	// NotifyPods instructs the notifier to call the passed in function when
-	// the pod status changes.
+	// the pod status changes. It will be called prior to any imperative calls. It
+	// is only called once, at startup time of the PodController
 	//
 	// NotifyPods should not block callers.
 	NotifyPods(context.Context, func(*corev1.Pod))
@@ -77,7 +87,8 @@ type PodNotifier interface {
 
 // PodController is the controller implementation for Pod resources.
 type PodController struct {
-	provider PodLifecycleHandler
+	provider   PodLifecycleHandler
+	providerV0 PodLifecycleHandlerV0
 
 	// podsInformer is an informer for Pod resources.
 	podsInformer corev1informers.PodInformer
@@ -110,7 +121,10 @@ type PodControllerConfig struct {
 
 	EventRecorder record.EventRecorder
 
-	Provider PodLifecycleHandler
+	// It is strongly preferred to specify a PodController here. If you specify a PodControllerV0
+	// here, it will be wrapped using WrapLegacyPodLifecycleHandler, with a wrap time specified
+	// by DefaultWrapLegacyPodLifecycleHandlerLoopTime
+	Provider PodLifecycleHandlerV0
 
 	// Informers used for filling details for things like downward API in pod spec.
 	//
@@ -153,18 +167,46 @@ func NewPodController(cfg PodControllerConfig) (*PodController, error) {
 		client:          cfg.PodClient,
 		podsInformer:    cfg.PodInformer,
 		podsLister:      cfg.PodInformer.Lister(),
-		provider:        cfg.Provider,
 		resourceManager: rm,
 		ready:           make(chan struct{}),
 		recorder:        cfg.EventRecorder,
 		k8sQ:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "syncPodsFromKubernetes"),
 	}
 
+	if podLifecycleHandler, ok := cfg.Provider.(PodLifecycleHandler); ok {
+		pc.provider = podLifecycleHandler
+	} else {
+		pc.providerV0 = podLifecycleHandler
+	}
+
+	return pc, nil
+}
+
+// Run will set up the event handlers for types we are interested in, as well as syncing informer caches and starting workers.
+// It will block until the context is cancelled, at which point it will shutdown the work queue and wait for workers to finish processing their current work items.
+func (pc *PodController) Run(ctx context.Context, podSyncWorkers int) error {
+	defer pc.k8sQ.ShutDown()
+
+	if pc.providerV0 != nil {
+		pc.provider = WrapLegacyPodLifecycleHandler(ctx, pc.providerV0, DefaultWrapLegacyPodLifecycleHandlerLoopTime)
+	}
+
+	podStatusQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "syncPodStatusFromProvider")
+	pc.runSyncFromProvider(ctx, podStatusQueue)
+	pc.runProviderSyncWorkers(ctx, podStatusQueue, podSyncWorkers)
+	defer podStatusQueue.ShutDown()
+
+	// Wait for the caches to be synced *before* starting workers.
+	if ok := cache.WaitForCacheSync(ctx.Done(), pc.podsInformer.Informer().HasSynced); !ok {
+		return pkgerrors.New("failed to wait for caches to sync")
+	}
+	log.G(ctx).Info("Pod cache in-sync")
+
 	// Set up event handlers for when Pod resources change.
 	pc.podsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(pod interface{}) {
 			if key, err := cache.MetaNamespaceKeyFunc(pod); err != nil {
-				log.L.Error(err)
+				log.G(ctx).Error(err)
 			} else {
 				pc.k8sQ.AddRateLimited(key)
 			}
@@ -183,43 +225,28 @@ func NewPodController(cfg PodControllerConfig) (*PodController, error) {
 			}
 			// At this point we know that something in .metadata or .spec has changed, so we must proceed to sync the pod.
 			if key, err := cache.MetaNamespaceKeyFunc(newPod); err != nil {
-				log.L.Error(err)
+				log.G(ctx).Error(err)
 			} else {
 				pc.k8sQ.AddRateLimited(key)
 			}
 		},
 		DeleteFunc: func(pod interface{}) {
 			if key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(pod); err != nil {
-				log.L.Error(err)
+				log.G(ctx).Error(err)
 			} else {
 				pc.k8sQ.AddRateLimited(key)
 			}
 		},
 	})
 
-	return pc, nil
-}
-
-// Run will set up the event handlers for types we are interested in, as well as syncing informer caches and starting workers.
-// It will block until the context is cancelled, at which point it will shutdown the work queue and wait for workers to finish processing their current work items.
-func (pc *PodController) Run(ctx context.Context, podSyncWorkers int) error {
-	defer pc.k8sQ.ShutDown()
-
-	podStatusQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "syncPodStatusFromProvider")
-	pc.runSyncFromProvider(ctx, podStatusQueue)
-	pc.runProviderSyncWorkers(ctx, podStatusQueue, podSyncWorkers)
-	defer podStatusQueue.ShutDown()
-
-	// Wait for the caches to be synced *before* starting workers.
-	if ok := cache.WaitForCacheSync(ctx.Done(), pc.podsInformer.Informer().HasSynced); !ok {
-		return pkgerrors.New("failed to wait for caches to sync")
-	}
-	log.G(ctx).Info("Pod cache in-sync")
-
 	// Perform a reconciliation step that deletes any dangling pods from the provider.
 	// This happens only when the virtual-kubelet is starting, and operates on a "best-effort" basis.
 	// If by any reason the provider fails to delete a dangling pod, it will stay in the provider and deletion won't be retried.
 	pc.deleteDanglingPods(ctx, podSyncWorkers)
+
+	if wrappedPodLifecycleHandler, ok := pc.provider.(WrappedPodLifecycleHandler); ok {
+		go wrappedPodLifecycleHandler.run(ctx)
+	}
 
 	log.G(ctx).Info("starting workers")
 	for id := 0; id < podSyncWorkers; id++ {


### PR DESCRIPTION
    Introduce PodLifecycleHandlerV0 interface
    
    This breaks out the PodLifecycleHandlerV0 interface. The PodNotifier
    interface gives a false sense of what we expect people to implement.
    
    In addition, it marks the PodLifecycleHandlerV0 as deprecated.
    
    Lastly, it breaks out the wrapper code. The benefit of breaking
    out the wrapper code is that now people can customize their
    reconcilation loop time based on their provider's capabilities.