### PR TITLE
Set timeout for tests on CI to  9 minutes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ ifndef CI
 else
 	@echo "Testing in CI..."
 	$Q mkdir -p test
-	$Q ( GODEBUG=cgocheck=2 go test -v $(allpackages); echo $$? ) | \
+	$Q ( GODEBUG=cgocheck=2 go test -timeout=9m -v $(allpackages); echo $$? ) | \
        tee test/output.txt | sed '$$ d'; exit $$(tail -1 test/output.txt)
 endif
 


### PR DESCRIPTION
Right now, if the tests get stuck (on CI), they are terminated
after 10 minutes. This means as well that we get 0 output about
what went wrong.

Instead, this triggers a panic after 9 minutes on CI.