### PR TITLE
Remove usage of atomics in tests

### DIFF
--- a/node/lifecycle_test.go
+++ b/node/lifecycle_test.go
@@ -333,6 +333,7 @@ func testTerminalStatePodScenario(ctx context.Context, t *testing.T, s *system, 
 	s.start(ctx)
 
 	for s.pc.k8sQ.Len() > 0 {
+		time.Sleep(10 * time.Millisecond)
 	}
 
 	p2, err := s.client.CoreV1().Pods(testNamespace).Get(p1.Name, metav1.GetOptions{})


### PR DESCRIPTION
It turns out that running atomic.Read(...) in a tight loop breaks
Golang. The goroutine would never yield control over the scheduler,
so we ended up getting into a situation where the test would get
stuck forever. This moves to a different model, in which
there is a condition var, instead of atomics in loops.