### PR TITLE
Fix deadlock around scheduling in lifecycle_test

### DIFF
--- a/node/lifecycle_test.go
+++ b/node/lifecycle_test.go
@@ -344,6 +344,7 @@ func testTerminalStatePodScenario(ctx context.Context, t *testing.T, s *system, 
 	s.start(ctx)
 
 	for s.pc.k8sQ.Len() > 0 {
+		time.Sleep(10 * time.Millisecond)
 	}
 
 	p2, err := s.client.CoreV1().Pods(testNamespace).Get(p1.Name, metav1.GetOptions{})


### PR DESCRIPTION
Lifecycle test had a deadlock, where it would run a never-yielding
function while processing was going on elsewhere. This inserts
a sleep. A sleep is used rather than a yield to be kind to
people's battery life.