### PR TITLE
Add methods to wait for pod controller exit and errors

### DIFF
--- a/node/doc.go
+++ b/node/doc.go
@@ -27,9 +27,10 @@ There are two primary controllers, the node runner and the pod runner.
 
 	select {
 	case <-podRunner.Ready():
-		go nodeRunner.Run(ctx)
-	case <-ctx.Done()
-		return ctx.Err()
+	case <-podRunner.Done():
+	}
+	if podRunner.Err() != nil {
+		// handle error
 	}
 
 After calling start, cancelling the passed in context will shutdown the

--- a/node/podcontroller_test.go
+++ b/node/podcontroller_test.go
@@ -1,0 +1,44 @@
+package node
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+)
+
+func TestPodControllerExitOnContextCancel(t *testing.T) {
+	tc := newTestController()
+	ctx := context.Background()
+	ctxRun, cancel := context.WithCancel(ctx)
+
+	done := make(chan error)
+	go func() {
+		done <- tc.Run(ctxRun, 1)
+	}()
+
+	ctxT, cancelT := context.WithTimeout(ctx, 30*time.Second)
+	select {
+	case <-ctx.Done():
+		assert.NilError(t, ctxT.Err())
+	case <-tc.Ready():
+	case <-tc.Done():
+	}
+	assert.NilError(t, tc.Err())
+
+	cancelT()
+
+	cancel()
+
+	ctxT, cancelT = context.WithTimeout(ctx, 30*time.Second)
+	defer cancelT()
+
+	select {
+	case <-ctxT.Done():
+		assert.NilError(t, ctxT.Err(), "timeout waiting for Run() to exit")
+	case err := <-done:
+		assert.NilError(t, err)
+	}
+	assert.NilError(t, tc.Err())
+}


### PR DESCRIPTION
    Adds Done() and Err() to pod controller

    Allows callers to wait for pod controller exit in addition to readiness.
    This means the caller does not have to deal handling errors from the pod
    controller running in a gorutine since it can wait for exit via `Done()`
    and check the error with `Err()`