### PR TITLE
Handle providers which do not implement UpdatePod

### DIFF
--- a/errdefs/unsupported.go
+++ b/errdefs/unsupported.go
@@ -1,0 +1,65 @@
+package errdefs
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrUnsupported is an error interface which denotes whether the operation failed due
+// to the operation being unsupported. It will not succeed on subsequent retries.
+type ErrUnsupported interface {
+	Unsupported() bool
+	error
+}
+
+type unsupportedError struct {
+	error
+}
+
+func (e *unsupportedError) Unsupported() bool {
+	return true
+}
+
+func (e *unsupportedError) Cause() error {
+	return e.error
+}
+
+// AsUnsupported wraps the passed in error to make it of type ErrUnsupported
+//
+// Callers should make sure the passed in error has exactly the error message
+// it wants as this function does not decorate the message.
+func AsUnsupported(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &unsupportedError{err}
+}
+
+// Unsupported makes an ErrUnsupported from the provided error message
+func Unsupported(msg string) error {
+	return &unsupportedError{errors.New(msg)}
+}
+
+// Unsupportedf makes an ErrUnsupported from the provided error format and args
+func Unsupportedf(format string, args ...interface{}) error {
+	return &unsupportedError{fmt.Errorf(format, args...)}
+}
+
+// IsUnsupported determines if the passed in error is of type ErrUnsupported
+//
+// This will traverse the causal chain (`Cause() error`), until it finds an error
+// which implements the `NotFound` interface.
+func IsUnsupported(err error) bool {
+	if err == nil {
+		return false
+	}
+	if e, ok := err.(ErrUnsupported); ok {
+		return e.Unsupported()
+	}
+
+	if e, ok := err.(causal); ok {
+		return IsUnsupported(e.Cause())
+	}
+
+	return false
+}

--- a/errdefs/unsupported_test.go
+++ b/errdefs/unsupported_test.go
@@ -1,0 +1,82 @@
+package errdefs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+	"gotest.tools/assert"
+	"gotest.tools/assert/cmp"
+)
+
+type testingUnsupportedError bool
+
+func (e testingUnsupportedError) Error() string {
+	return fmt.Sprintf("%v", bool(e))
+}
+
+func (e testingUnsupportedError) Unsupported() bool {
+	return bool(e)
+}
+
+func TestIsUnsupported(t *testing.T) {
+	type testCase struct {
+		name         string
+		err          error
+		xMsg         string
+		xUnsupported bool
+	}
+
+	for _, c := range []testCase{
+		{
+			name:         "Unsupportedf",
+			err:          Unsupportedf("%s unsupported", "foo"),
+			xMsg:         "foo unsupported",
+			xUnsupported: true,
+		},
+		{
+			name:         "AsUnsupported",
+			err:          AsUnsupported(errors.New("this is a test")),
+			xMsg:         "this is a test",
+			xUnsupported: true,
+		},
+		{
+			name:         "AsUnsupportedWithNil",
+			err:          AsUnsupported(nil),
+			xMsg:         "",
+			xUnsupported: false,
+		},
+		{
+			name:         "nilError",
+			err:          nil,
+			xMsg:         "",
+			xUnsupported: false,
+		},
+		{
+			name:         "customUnsupportedFalse",
+			err:          testingUnsupportedError(false),
+			xMsg:         "false",
+			xUnsupported: false,
+		},
+		{
+			name:         "customUnsupportedTrue",
+			err:          testingUnsupportedError(true),
+			xMsg:         "true",
+			xUnsupported: true,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Check(t, cmp.Equal(IsUnsupported(c.err), c.xUnsupported))
+			if c.err != nil {
+				assert.Check(t, cmp.Equal(c.err.Error(), c.xMsg))
+			}
+		})
+	}
+}
+
+func TestUnsupportedCause(t *testing.T) {
+	err := errors.New("test")
+	e := &unsupportedError{err}
+	assert.Check(t, cmp.Equal(e.Cause(), err))
+	assert.Check(t, IsUnsupported(errors.Wrap(e, "some details")))
+}


### PR DESCRIPTION
This addresses the issue where certain (optional) APIs are unimplemented by the provider. 