### PR TITLE
Make exec timeout configurable

### DIFF
--- a/cmd/virtual-kubelet/internal/commands/root/flag.go
+++ b/cmd/virtual-kubelet/internal/commands/root/flag.go
@@ -81,6 +81,11 @@ func installFlags(flags *pflag.FlagSet, c *Opts) {
 
 	flags.DurationVar(&c.InformerResyncPeriod, "full-resync-period", c.InformerResyncPeriod, "how often to perform a full resync of pods between kubernetes and the provider")
 	flags.DurationVar(&c.StartupTimeout, "startup-timeout", c.StartupTimeout, "How long to wait for the virtual-kubelet to start")
+	flags.DurationVar(&c.StreamIdleTimeout, "stream-idle-timeout", c.StreamIdleTimeout,
+		"stream-idle-timeout is the maximum time a streaming connection can be idle before the connection is"+
+			" automatically closed, default 30s.")
+	flags.DurationVar(&c.StreamCreationTimeout, "stream-creation-timeout", c.StreamCreationTimeout,
+		"stream-creation-timeout is the maximum time for streaming connection, default 30s.")
 
 	flagset := flag.NewFlagSet("klog", flag.PanicOnError)
 	klog.InitFlags(flagset)

--- a/cmd/virtual-kubelet/internal/commands/root/http.go
+++ b/cmd/virtual-kubelet/internal/commands/root/http.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/virtual-kubelet/virtual-kubelet/cmd/virtual-kubelet/internal/provider"
@@ -92,7 +93,7 @@ func setupHTTPServer(ctx context.Context, p provider.Provider, cfg *apiServerCon
 			GetContainerLogs: p.GetContainerLogs,
 			GetPods:          p.GetPods,
 		}
-		api.AttachPodRoutes(podRoutes, mux, true)
+		api.AttachPodRoutes(podRoutes, mux, true, cfg.StreamIdleTimeout, cfg.StreamCreationTimeout)
 
 		s := &http.Server{
 			Handler:   mux,
@@ -142,10 +143,12 @@ func serveHTTP(ctx context.Context, s *http.Server, l net.Listener, name string)
 }
 
 type apiServerConfig struct {
-	CertPath    string
-	KeyPath     string
-	Addr        string
-	MetricsAddr string
+	CertPath              string
+	KeyPath               string
+	Addr                  string
+	MetricsAddr           string
+	StreamIdleTimeout     time.Duration
+	StreamCreationTimeout time.Duration
 }
 
 func getAPIConfig(c Opts) (*apiServerConfig, error) {
@@ -156,6 +159,8 @@ func getAPIConfig(c Opts) (*apiServerConfig, error) {
 
 	config.Addr = fmt.Sprintf(":%d", c.ListenPort)
 	config.MetricsAddr = c.MetricsAddr
+	config.StreamIdleTimeout = c.StreamIdleTimeout
+	config.StreamCreationTimeout = c.StreamCreationTimeout
 
 	return &config, nil
 }

--- a/cmd/virtual-kubelet/internal/commands/root/http.go
+++ b/cmd/virtual-kubelet/internal/commands/root/http.go
@@ -89,11 +89,14 @@ func setupHTTPServer(ctx context.Context, p provider.Provider, cfg *apiServerCon
 		mux := http.NewServeMux()
 
 		podRoutes := api.PodHandlerConfig{
-			RunInContainer:   p.RunInContainer,
-			GetContainerLogs: p.GetContainerLogs,
-			GetPods:          p.GetPods,
+			RunInContainer:        p.RunInContainer,
+			GetContainerLogs:      p.GetContainerLogs,
+			GetPods:               p.GetPods,
+			StreamIdleTimeout:     cfg.StreamIdleTimeout,
+			StreamCreationTimeout: cfg.StreamCreationTimeout,
 		}
-		api.AttachPodRoutes(podRoutes, mux, true, cfg.StreamIdleTimeout, cfg.StreamCreationTimeout)
+
+		api.AttachPodRoutes(podRoutes, mux, true)
 
 		s := &http.Server{
 			Handler:   mux,

--- a/cmd/virtual-kubelet/internal/commands/root/opts.go
+++ b/cmd/virtual-kubelet/internal/commands/root/opts.go
@@ -36,8 +36,10 @@ const (
 	DefaultKubeNamespace        = corev1.NamespaceAll
 	DefaultKubeClusterDomain    = "cluster.local"
 
-	DefaultTaintEffect = string(corev1.TaintEffectNoSchedule)
-	DefaultTaintKey    = "virtual-kubelet.io/provider"
+	DefaultTaintEffect           = string(corev1.TaintEffectNoSchedule)
+	DefaultTaintKey              = "virtual-kubelet.io/provider"
+	DefaultStreamIdleTimeout     = 30 * time.Second
+	DefaultStreamCreationTimeout = 30 * time.Second
 )
 
 // Opts stores all the options for configuring the root virtual-kubelet command.
@@ -84,6 +86,11 @@ type Opts struct {
 
 	// Startup Timeout is how long to wait for the kubelet to start
 	StartupTimeout time.Duration
+	// StreamIdleTimeout is the maximum time a streaming connection
+	// can be idle before the connection is automatically closed.
+	StreamIdleTimeout time.Duration
+	// StreamCreationTimeout is the maximum time for streaming connection
+	StreamCreationTimeout time.Duration
 
 	Version string
 }
@@ -150,6 +157,14 @@ func SetDefaultOpts(c *Opts) error {
 				c.KubeConfigPath = filepath.Join(home, ".kube", "config")
 			}
 		}
+	}
+
+	if c.StreamIdleTimeout == 0 {
+		c.StreamIdleTimeout = DefaultStreamIdleTimeout
+	}
+
+	if c.StreamCreationTimeout == 0 {
+		c.StreamCreationTimeout = DefaultStreamCreationTimeout
 	}
 
 	return nil

--- a/node/api/exec.go
+++ b/node/api/exec.go
@@ -123,7 +123,7 @@ func HandleContainerExec(h ContainerExecHandlerFunc, opts ...ContainerExecHandle
 			streamOpts,
 			cfg.StreamIdleTimeout,
 			cfg.StreamCreationTimeout,
-			supportedStreamProtocols.
+			supportedStreamProtocols,
 		)
 
 		return nil

--- a/node/api/exec.go
+++ b/node/api/exec.go
@@ -52,7 +52,8 @@ type TermSize struct {
 // HandleContainerExec makes an http handler func from a Provider which execs a command in a pod's container
 // Note that this handler currently depends on gorrilla/mux to get url parts as variables.
 // TODO(@cpuguy83): don't force gorilla/mux on consumers of this function
-func HandleContainerExec(h ContainerExecHandlerFunc) http.HandlerFunc {
+func HandleContainerExec(h ContainerExecHandlerFunc, streamIdleTimeout, streamCreationTimeout time.Duration) http.
+	HandlerFunc {
 	if h == nil {
 		return NotImplemented
 	}
@@ -73,14 +74,12 @@ func HandleContainerExec(h ContainerExecHandlerFunc) http.HandlerFunc {
 			return errdefs.AsInvalidInput(err)
 		}
 
-		idleTimeout := time.Second * 30
-		streamCreationTimeout := time.Second * 30
-
 		ctx, cancel := context.WithCancel(context.TODO())
 		defer cancel()
 
 		exec := &containerExecContext{ctx: ctx, h: h, pod: pod, namespace: namespace, container: container}
-		remotecommand.ServeExec(w, req, exec, "", "", container, command, streamOpts, idleTimeout, streamCreationTimeout, supportedStreamProtocols)
+		remotecommand.ServeExec(w, req, exec, "", "", container, command, streamOpts, streamIdleTimeout,
+			streamCreationTimeout, supportedStreamProtocols)
 
 		return nil
 	})

--- a/node/api/exec.go
+++ b/node/api/exec.go
@@ -52,7 +52,38 @@ type TermSize struct {
 // HandleContainerExec makes an http handler func from a Provider which execs a command in a pod's container
 // Note that this handler currently depends on gorrilla/mux to get url parts as variables.
 // TODO(@cpuguy83): don't force gorilla/mux on consumers of this function
-func HandleContainerExec(h ContainerExecHandlerFunc, streamIdleTimeout, streamCreationTimeout time.Duration) http.
+// ContainerExecHandlerConfig is used to pass options to options to the container exec handler.
+type ContainerExecHandlerConfig {
+	// StreamIdleTimeout is the maximum time a streaming connection
+	// can be idle before the connection is automatically closed.
+	StreamCreationTimeout time.Duration
+	// StreamCreationTimeout is the maximum time for streaming connection
+	StreamCreationTimeout time.Duration
+}
+
+// ContainerExecHandlerOption configures a ContainerExecHandlerConfig
+// It is used as functional options passed to `HandleContainerExec`
+type ContainerExecHandlerOption func(*ContainerExecHandlerConfig)
+
+// WithExecStreamIdleTimeout sets the idle timeout for a container exec stream
+func WithExecStreamIdleTimeout(dur time.Duration) ContainerExecHandlerOption {
+	return func(cfg *ContainerExecHandlerConfig) {
+		cfg.StreamIdleTimeout = dur
+	}
+}
+
+// HandleContainerExec makes an http handler func from a Provider which execs a command in a pod's container
+// Note that this handler currently depends on gorrilla/mux to get url parts as variables.
+// TODO(@cpuguy83): don't force gorilla/mux on consumers of this function
+func HandleContainerExec(h ContainerExecHandlerFunc, opts ..ContainerExecHandlerOption) HandlerFunc {
+    if h == nil {
+    	return NotImplemented
+    }
+    
+    var cfg ContainerExecHandlerConfig
+    for _, o := range opts {
+    	o(&cfg)
+    }
 	HandlerFunc {
 	if h == nil {
 		return NotImplemented

--- a/node/api/exec.go
+++ b/node/api/exec.go
@@ -112,8 +112,19 @@ func HandleContainerExec(h ContainerExecHandlerFunc, opts ...ContainerExecHandle
 		defer cancel()
 
 		exec := &containerExecContext{ctx: ctx, h: h, pod: pod, namespace: namespace, container: container}
-		remotecommand.ServeExec(w, req, exec, "", "", container, command, streamOpts, cfg.StreamIdleTimeout,
-			cfg.StreamCreationTimeout, supportedStreamProtocols)
+		remotecommand.ServeExec(
+			w,
+			req,
+			exec,
+			"",
+			"",
+			container,
+			command,
+			streamOpts,
+			cfg.StreamIdleTimeout,
+			cfg.StreamCreationTimeout,
+			supportedStreamProtocols.
+		)
 
 		return nil
 	})

--- a/node/api/server.go
+++ b/node/api/server.go
@@ -52,8 +52,14 @@ func PodHandler(p PodHandlerConfig, debug bool) http.Handler {
 	}
 
 	r.HandleFunc("/containerLogs/{namespace}/{pod}/{container}", HandleContainerLogs(p.GetContainerLogs)).Methods("GET")
-	r.HandleFunc("/exec/{namespace}/{pod}/{container}", HandleContainerExec(p.RunInContainer,
-		WithExecStreamCreationTimeout(p.StreamCreationTimeout), WithExecStreamIdleTimeout(p.StreamIdleTimeout))).Methods("POST")
+	r.HandleFunc(
+		"/exec/{namespace}/{pod}/{container}",
+		HandleContainerExec(
+			p.RunInContainer,
+			WithExecStreamCreationTimeout(p.StreamCreationTimeout),
+			WithExecStreamIdleTimeout(p.StreamIdleTimeout),
+		),
+	).Methods("POST")
 	r.NotFoundHandler = http.HandlerFunc(NotFound)
 	return r
 }

--- a/node/api/server.go
+++ b/node/api/server.go
@@ -50,9 +50,10 @@ func PodHandler(p PodHandlerConfig, debug bool) http.Handler {
 	if debug {
 		r.HandleFunc("/runningpods/", HandleRunningPods(p.GetPods)).Methods("GET")
 	}
+
 	r.HandleFunc("/containerLogs/{namespace}/{pod}/{container}", HandleContainerLogs(p.GetContainerLogs)).Methods("GET")
-	r.HandleFunc("/exec/{namespace}/{pod}/{container}", HandleContainerExec(p.RunInContainer, p.StreamIdleTimeout,
-		p.StreamCreationTimeout)).Methods("POST")
+	r.HandleFunc("/exec/{namespace}/{pod}/{container}", HandleContainerExec(p.RunInContainer,
+		WithExecStreamCreationTimeout(p.StreamCreationTimeout), WithExecStreamIdleTimeout(p.StreamIdleTimeout))).Methods("POST")
 	r.NotFoundHandler = http.HandlerFunc(NotFound)
 	return r
 }


### PR DESCRIPTION
Make exec timeout configurable

See 
https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/apis/config/types.go#L165
https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet.go#L2296

kubelet also allows to change default steamIdleTimeout, so I think it's to reasonable to make it configurable

Fix: https://github.com/virtual-kubelet/virtual-kubelet/issues/791