### PR TITLE
Use correct Flush() prototype from http.Flusher

### DIFF
--- a/node/api/helpers.go
+++ b/node/api/helpers.go
@@ -56,16 +56,14 @@ type flushWriter struct {
 }
 
 type writeFlusher interface {
-	Flush() error
+	Flush()
 	Write([]byte) (int, error)
 }
 
 func (fw *flushWriter) Write(p []byte) (int, error) {
 	n, err := fw.w.Write(p)
 	if n > 0 {
-		if err := fw.w.Flush(); err != nil {
-			return n, err
-		}
+		fw.w.Flush()
 	}
 	return n, err
 }


### PR DESCRIPTION
When calling GetContainerLogs(), a type check is performed to see if the
http.ResponseWriter supports flushing. However, Flush() in http.Flusher
does not return an error, therefore the type check will always fail.

Fix the flushWriter helper interface so flushing the writer will work.