### PR TITLE
add 'GET' method to pod exec handler, so it can support websocket

### DIFF
--- a/node/api/server.go
+++ b/node/api/server.go
@@ -59,7 +59,7 @@ func PodHandler(p PodHandlerConfig, debug bool) http.Handler {
 			WithExecStreamCreationTimeout(p.StreamCreationTimeout),
 			WithExecStreamIdleTimeout(p.StreamIdleTimeout),
 		),
-	).Methods("POST")
+	).Methods("POST", "GET")
 	r.NotFoundHandler = http.HandlerFunc(NotFound)
 	return r
 }


### PR DESCRIPTION
I found a BUG in virtual-kubelet:
users trying to do pod exec with WebSocket will end with 405, while pod exec with SPDY will be ok.
The reason is:

WebSocket usually starts handshake with a http request of 'GET'
pod exec handler in virtual-kubelet only register 'POST' method
PS：code of pod exec handler in virtual-kubelet actually suport both WebSocket and SPDY