### PR TITLE
Check pods status deep equal before update

### DIFF
--- a/node/pod.go
+++ b/node/pod.go
@@ -213,6 +213,10 @@ func (pc *PodController) enqueuePodStatusUpdate(ctx context.Context, q workqueue
 		if obj, ok := pc.knownPods.Load(key); ok {
 			kpod := obj.(*knownPod)
 			kpod.Lock()
+			if cmp.Equal(kpod.lastPodStatusReceivedFromProvider, pod) {
+				kpod.Unlock()
+				return
+			}
 			kpod.lastPodStatusReceivedFromProvider = pod
 			kpod.Unlock()
 			q.AddRateLimited(key)


### PR DESCRIPTION
Check pods status deep equal before update. If we do not check it, we would update pod status frequently and reach the qps limit quickly.