### PR TITLE
Fix running pods handler on nil lister

### DIFF
--- a/node/api/pods.go
+++ b/node/api/pods.go
@@ -27,6 +27,10 @@ import (
 type PodListerFunc func(context.Context) ([]*v1.Pod, error)
 
 func HandleRunningPods(getPods PodListerFunc) http.HandlerFunc {
+	if getPods == nil {
+		return NotImplemented
+	}
+
 	scheme := runtime.NewScheme()
 	v1.SchemeBuilder.AddToScheme(scheme) //nolint:errcheck
 	codecs := serializer.NewCodecFactory(scheme)


### PR DESCRIPTION
This follows suit with other hanlders and returns a NotImplemented
http.HandlerFunc when the lister is nil.