### PR TITLE
Use /stats/summary for metrics handler

### DIFF
--- a/node/api/server.go
+++ b/node/api/server.go
@@ -40,6 +40,7 @@ type PodHandlerConfig struct {
 	GetPods PodListerFunc
 	// GetPodsFromKubernetes is meant to enumerate the pods that the node is meant to be running
 	GetPodsFromKubernetes PodListerFunc
+	GetStatsSummary       PodStatsSummaryHandlerFunc
 	StreamIdleTimeout     time.Duration
 	StreamCreationTimeout time.Duration
 }
@@ -64,6 +65,13 @@ func PodHandler(p PodHandlerConfig, debug bool) http.Handler {
 			WithExecStreamIdleTimeout(p.StreamIdleTimeout),
 		),
 	).Methods("POST", "GET")
+
+	if p.GetStatsSummary != nil {
+		f := HandlePodStatsSummary(p.GetStatsSummary)
+		r.HandleFunc("/stats/summary", f).Methods("GET")
+		r.HandleFunc("/stats/summary/", f).Methods("GET")
+	}
+
 	r.NotFoundHandler = http.HandlerFunc(NotFound)
 	return r
 }


### PR DESCRIPTION
To allow users to attach both the pod and metrics handlers to the same mux, use "/stats/summary" as the pattern in AttachPodMetricsRoutes. Otherwise, if mux.Handle() is called again for the same pattern, it will panic, and this is what happens in node-cli due to https://github.com/virtual-kubelet/node-cli/pull/27 calling both AttachPodRoutes() AttachPodMetricsRoutes() with the same mux.