### PR TITLE
Add controller manager to remove boiler plate code

### DIFF
--- a/cmd/virtual-kubelet/internal/commands/root/http.go
+++ b/cmd/virtual-kubelet/internal/commands/root/http.go
@@ -15,19 +15,9 @@
 package root
 
 import (
-	"context"
 	"crypto/tls"
-	"fmt"
-	"io"
-	"net"
-	"net/http"
-	"os"
-	"time"
 
 	"github.com/pkg/errors"
-	"github.com/virtual-kubelet/virtual-kubelet/cmd/virtual-kubelet/internal/provider"
-	"github.com/virtual-kubelet/virtual-kubelet/log"
-	"github.com/virtual-kubelet/virtual-kubelet/node/api"
 )
 
 // AcceptedCiphers is the list of accepted TLS ciphers, with known weak ciphers elided
@@ -56,115 +46,4 @@ func loadTLSConfig(certPath, keyPath string) (*tls.Config, error) {
 		PreferServerCipherSuites: true,
 		CipherSuites:             AcceptedCiphers,
 	}, nil
-}
-
-func setupHTTPServer(ctx context.Context, p provider.Provider, cfg *apiServerConfig, getPodsFromKubernetes api.PodListerFunc) (_ func(), retErr error) {
-	var closers []io.Closer
-	cancel := func() {
-		for _, c := range closers {
-			c.Close()
-		}
-	}
-	defer func() {
-		if retErr != nil {
-			cancel()
-		}
-	}()
-
-	if cfg.CertPath == "" || cfg.KeyPath == "" {
-		log.G(ctx).
-			WithField("certPath", cfg.CertPath).
-			WithField("keyPath", cfg.KeyPath).
-			Error("TLS certificates not provided, not setting up pod http server")
-	} else {
-		tlsCfg, err := loadTLSConfig(cfg.CertPath, cfg.KeyPath)
-		if err != nil {
-			return nil, err
-		}
-		l, err := tls.Listen("tcp", cfg.Addr, tlsCfg)
-		if err != nil {
-			return nil, errors.Wrap(err, "error setting up listener for pod http server")
-		}
-
-		mux := http.NewServeMux()
-
-		podRoutes := api.PodHandlerConfig{
-			RunInContainer:        p.RunInContainer,
-			GetContainerLogs:      p.GetContainerLogs,
-			GetPodsFromKubernetes: getPodsFromKubernetes,
-			GetPods:               p.GetPods,
-			StreamIdleTimeout:     cfg.StreamIdleTimeout,
-			StreamCreationTimeout: cfg.StreamCreationTimeout,
-		}
-
-		api.AttachPodRoutes(podRoutes, mux, true)
-
-		s := &http.Server{
-			Handler:   mux,
-			TLSConfig: tlsCfg,
-		}
-		go serveHTTP(ctx, s, l, "pods")
-		closers = append(closers, s)
-	}
-
-	if cfg.MetricsAddr == "" {
-		log.G(ctx).Info("Pod metrics server not setup due to empty metrics address")
-	} else {
-		l, err := net.Listen("tcp", cfg.MetricsAddr)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not setup listener for pod metrics http server")
-		}
-
-		mux := http.NewServeMux()
-
-		var summaryHandlerFunc api.PodStatsSummaryHandlerFunc
-		if mp, ok := p.(provider.PodMetricsProvider); ok {
-			summaryHandlerFunc = mp.GetStatsSummary
-		}
-		podMetricsRoutes := api.PodMetricsConfig{
-			GetStatsSummary: summaryHandlerFunc,
-		}
-		api.AttachPodMetricsRoutes(podMetricsRoutes, mux)
-		s := &http.Server{
-			Handler: mux,
-		}
-		go serveHTTP(ctx, s, l, "pod metrics")
-		closers = append(closers, s)
-	}
-
-	return cancel, nil
-}
-
-func serveHTTP(ctx context.Context, s *http.Server, l net.Listener, name string) {
-	if err := s.Serve(l); err != nil {
-		select {
-		case <-ctx.Done():
-		default:
-			log.G(ctx).WithError(err).Errorf("Error setting up %s http server", name)
-		}
-	}
-	l.Close()
-}
-
-type apiServerConfig struct {
-	CertPath              string
-	KeyPath               string
-	Addr                  string
-	MetricsAddr           string
-	StreamIdleTimeout     time.Duration
-	StreamCreationTimeout time.Duration
-}
-
-func getAPIConfig(c Opts) (*apiServerConfig, error) {
-	config := apiServerConfig{
-		CertPath: os.Getenv("APISERVER_CERT_LOCATION"),
-		KeyPath:  os.Getenv("APISERVER_KEY_LOCATION"),
-	}
-
-	config.Addr = fmt.Sprintf(":%d", c.ListenPort)
-	config.MetricsAddr = c.MetricsAddr
-	config.StreamIdleTimeout = c.StreamIdleTimeout
-	config.StreamCreationTimeout = c.StreamCreationTimeout
-
-	return &config, nil
 }

--- a/cmd/virtual-kubelet/internal/provider/mock/mock.go
+++ b/cmd/virtual-kubelet/internal/provider/mock/mock.go
@@ -362,11 +362,11 @@ func (p *MockProvider) nodeConditions() []v1.NodeCondition {
 	return []v1.NodeCondition{
 		{
 			Type:               "Ready",
-			Status:             v1.ConditionTrue,
+			Status:             v1.ConditionFalse,
 			LastHeartbeatTime:  metav1.Now(),
 			LastTransitionTime: metav1.Now(),
-			Reason:             "KubeletReady",
-			Message:            "kubelet is ready.",
+			Reason:             "KubeletPending",
+			Message:            "kubelet is pending.",
 		},
 		{
 			Type:               "OutOfDisk",

--- a/hack/skaffold/virtual-kubelet/pod.yml
+++ b/hack/skaffold/virtual-kubelet/pod.yml
@@ -30,11 +30,4 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
-    ports:
-    - name: metrics
-      containerPort: 10255
-    readinessProbe:
-      httpGet:
-        path: /stats/summary
-        port: metrics
   serviceAccountName: virtual-kubelet

--- a/internal/test/e2e/framework/stats.go
+++ b/internal/test/e2e/framework/stats.go
@@ -18,7 +18,7 @@ func (f *Framework) GetStatsSummary(ctx context.Context) (*stats.Summary, error)
 		Namespace(f.Namespace).
 		Resource("pods").
 		SubResource("proxy").
-		Name(net.JoinSchemeNamePort("http", f.NodeName, strconv.Itoa(10255))).
+		Name(net.JoinSchemeNamePort("https", f.NodeName, strconv.Itoa(10250))).
 		Suffix("/stats/summary").DoRaw(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/test/suite/suite.go
+++ b/internal/test/suite/suite.go
@@ -21,7 +21,7 @@ type ShouldSkipTestFunc func(string) bool
 
 // TestSuite contains methods that defines the lifecycle of a test suite
 type TestSuite interface {
-	Setup()
+	Setup(t *testing.T)
 	Teardown()
 }
 
@@ -39,7 +39,7 @@ type testCase struct {
 func Run(t *testing.T, ts TestSuite) {
 	defer failOnPanic(t)
 
-	ts.Setup()
+	ts.Setup(t)
 	defer ts.Teardown()
 
 	// The implementation below is based on https://github.com/stretchr/testify

--- a/internal/test/suite/suite_test.go
+++ b/internal/test/suite/suite_test.go
@@ -20,7 +20,7 @@ type basicTestSuite struct {
 	testsRan        []string
 }
 
-func (bts *basicTestSuite) Setup() {
+func (bts *basicTestSuite) Setup(t *testing.T) {
 	bts.setupCount++
 }
 

--- a/node/api/controller.go
+++ b/node/api/controller.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"sync"
+
+	"github.com/virtual-kubelet/virtual-kubelet/errdefs"
+)
+
+// Controller is used for managing the HTTP API to serve pod routes.
+// E.g. API's for `kubectl exec` and `kubectl logs`.
+type Controller struct {
+	cfg ControllerConfig
+	srv *http.Server
+
+	ready chan struct{}
+	done  chan struct{}
+
+	mu  sync.Mutex
+	err error
+}
+
+// ControllerConfig holds options for the API controller
+type ControllerConfig struct {
+	// The listener that will serve pod routes
+	// If this is not provided, the controller will attempt to create a listener on the default kubelet port (10250).
+	PodListener net.Listener
+
+	// The TLSConfig will be used to serve TLS on the listener if provided.
+	// TLSConfig is required if PodListener is not set.
+	TLSConfig *tls.Config
+
+	// Config for route handlers
+	PodHandler PodHandlerConfig
+
+	// Enable debug routes
+	EnableDebug bool
+}
+
+// NewController creates a `Controller`, which manages an HTTP server instance
+// This does not run or start thing. To do that call `Run`
+func NewController(cfg ControllerConfig) (*Controller, error) {
+	if cfg.PodListener == nil && cfg.TLSConfig == nil {
+		return nil, errdefs.InvalidInput("must provide either a listener and/or a TLS config to configure a listener: refusing to listen on non-TLS port")
+	}
+
+	mux := &http.ServeMux{}
+	AttachPodRoutes(cfg.PodHandler, mux, cfg.EnableDebug)
+
+	return &Controller{
+		cfg:   cfg,
+		srv:   &http.Server{Handler: mux, TLSConfig: cfg.TLSConfig},
+		ready: make(chan struct{}),
+		done:  make(chan struct{}),
+	}, nil
+}
+
+// Run runs the controller
+// If the controller was created without a listener configured, this is where the listener will be started.
+//
+// This function does not return until the server is shutdown.
+// To shut down the server, you must cancel the past in context.
+//
+// You can check on the status of the controller with `Ready()` and `Done()`
+func (c *Controller) Run(ctx context.Context) (retErr error) {
+	defer func() {
+		c.mu.Lock()
+		c.err = retErr
+		c.mu.Unlock()
+		close(c.done)
+	}()
+
+	if c.cfg.PodListener == nil {
+		l, err := net.Listen("tcp", ":10250")
+		if err != nil {
+			return err
+		}
+		c.cfg.PodListener = l
+	}
+
+	if c.cfg.TLSConfig != nil {
+		c.cfg.PodListener = tls.NewListener(c.cfg.PodListener, c.cfg.TLSConfig)
+	}
+
+	go c.srv.Serve(c.cfg.PodListener)
+
+	close(c.ready)
+
+	<-ctx.Done()
+
+	c.srv.Close()
+
+	return ctx.Err()
+}
+
+// Ready returns a channel that will closed once the server is ready to serve content
+func (c *Controller) Ready() <-chan struct{} {
+	return c.ready
+}
+
+// Done returns a channel that will be closed once the server is no longer serving content.
+func (c *Controller) Done() <-chan struct{} {
+	return c.done
+}
+
+// Err returns whatever error is returned by `Run`
+func (c *Controller) Err() error {
+	c.mu.Lock()
+	err := c.err
+	c.mu.Unlock()
+	return err
+}

--- a/node/manager.go
+++ b/node/manager.go
@@ -1,0 +1,165 @@
+package node
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/virtual-kubelet/virtual-kubelet/log"
+	"github.com/virtual-kubelet/virtual-kubelet/node/api"
+)
+
+// ControllerManager can be used to setup pod and node controllers without requiring a bunch of boiler plate code.
+//
+// Create one with `NewControllerManager`, then start it with `ControllerManager.Start()`
+type ControllerManager struct {
+	pc *PodController
+	nc *NodeController
+	ac *api.Controller
+
+	pcWorkers      int
+	startupTimeout time.Duration
+
+	mu  sync.Mutex
+	err error
+
+	done  chan struct{}
+	ready chan struct{}
+}
+
+// Run starts up the controllers and waits for them to finish.
+//
+// This only returns once all controllers have finished.
+// You can check on the status asynchronously with `Ready()`, `Done()`, and `Err()`.
+func (m *ControllerManager) Run(ctx context.Context) (retErr error) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	defer func() {
+		cancel()
+
+		m.mu.Lock()
+		m.err = retErr
+		m.mu.Unlock()
+
+		close(m.done)
+		log.G(ctx).WithError(retErr).Debug("ControllerManager exiting")
+	}()
+
+	go func() {
+		err := m.pc.Run(ctx, m.pcWorkers)
+		log.G(ctx).WithError(err).Debug("Pod controller exited")
+		cancel()
+	}()
+
+	if err := waitReady(ctx, m.pc, m.startupTimeout); err != nil {
+		return errors.Wrap(err, "error waiting for pod controller to be ready")
+	}
+	log.G(ctx).Debug("Pod controller ready")
+
+	go func() {
+		err := m.nc.Run(ctx)
+		log.G(ctx).WithError(err).Debug("Node controller exited")
+		cancel()
+	}()
+
+	if err := waitReady(ctx, m.nc, m.startupTimeout); err != nil {
+		return errors.Wrap(err, "error waiting for node controller to be ready")
+	}
+	log.G(ctx).Debug("Node controller ready")
+
+	go func() {
+		err := m.ac.Run(ctx)
+		log.G(ctx).WithError(err).Debug("API controller exited")
+		cancel()
+	}()
+
+	if err := waitReady(ctx, m.ac, m.startupTimeout); err != nil {
+		return errors.Wrap(err, "error waiting for API controller")
+	}
+	log.G(ctx).Debug("API controller ready")
+
+	close(m.ready)
+	log.G(ctx).Debug("Controller manger ready")
+
+	select {
+	case <-m.nc.Done():
+		return m.nc.Err()
+	case <-m.pc.Done():
+		return m.pc.Err()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Ready returns a channel that gets closed when the node is fully up and
+// running. Note that if there is an error on startup this channel will never
+// be started.
+func (n *ControllerManager) Ready() <-chan struct{} {
+	return n.ready
+}
+
+// Done returns a channel that gets closed when the manager is no longer operating.
+// This means both the pod controller and the node controller are shutdown.
+func (n *ControllerManager) Done() <-chan struct{} {
+	return n.done
+}
+
+// Err returns whatever error is returned by `Run()`.
+// It allows the caller to check on the status of the without having to deal with setting up their own goroutines.
+// If this returns a non-nil error, the  manager is no longer operating.
+func (n *ControllerManager) Err() error {
+	n.mu.Lock()
+	err := n.err
+	n.mu.Unlock()
+	return err
+}
+
+func waitReady(ctx context.Context, w waiter, dur time.Duration) error {
+	if dur > 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, dur)
+		defer cancel()
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-w.Ready():
+		return w.Err()
+	case <-w.Done():
+		return w.Err()
+	}
+}
+
+type waiter interface {
+	Ready() <-chan struct{}
+	Done() <-chan struct{}
+	Err() error
+}
+
+// NewControllerManager creates a new ControllerManager.
+// The manager is not active until you call `Run`
+func NewControllerManager(cfg ControllerManagerConfig) (*ControllerManager, error) {
+	return &ControllerManager{
+		nc:             cfg.NodeController,
+		pc:             cfg.PodController,
+		ac:             cfg.APIController,
+		startupTimeout: cfg.StartupTimeout,
+		pcWorkers:      cfg.PodControllerWorkers,
+		done:           make(chan struct{}),
+		ready:          make(chan struct{}),
+	}, nil
+}
+
+// ControllerManagerConfig is how configuration is passed when creating a new manager.
+type ControllerManagerConfig struct {
+	NodeController *NodeController
+	PodController  *PodController
+	APIController  *api.Controller
+
+	// Number of workers for syncing between the pod provider and the Kubernetes API server.
+	PodControllerWorkers int
+
+	// Time to wait for each controller to be ready
+	StartupTimeout time.Duration
+}

--- a/node/nodeutil/client.go
+++ b/node/nodeutil/client.go
@@ -1,0 +1,58 @@
+package nodeutil
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/typed/coordination/v1beta1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// ClientsetFromEnv returns a kuberentes client set from:
+// 1. the passed in kubeconfig path
+// 2. If the kubeconfig path is empty or non-existent, then the in-cluster config is used.
+func ClientsetFromEnv(kubeConfigPath string) (*kubernetes.Clientset, error) {
+	var (
+		config *rest.Config
+		err    error
+	)
+
+	if kubeConfigPath != "" {
+		if _, err := os.Stat(kubeConfigPath); err != nil {
+			config, err = rest.InClusterConfig()
+		} else {
+			config, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+				&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeConfigPath},
+				nil,
+			).ClientConfig()
+		}
+	} else {
+		config, err = rest.InClusterConfig()
+	}
+
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting rest client config")
+	}
+
+	return kubernetes.NewForConfig(config)
+}
+
+// PodInformerFilter is a filter that you should use when creating a pod informer for use with the pod controller.
+func PodInformerFilter(node string) kubeinformers.SharedInformerOption {
+	return kubeinformers.WithTweakListOptions(func(options *metav1.ListOptions) {
+		options.FieldSelector = fields.OneTermEqualSelector("spec.nodeName", node).String()
+	})
+}
+
+// NodeLeaseV1Beta1Client creates a v1beta1 Lease client for use with node leases from the passed in client.
+//
+// Use this with node.WithNodeEnableLeaseV1Beta1 when creating a node controller.
+func NodeLeaseV1Beta1Client(client kubernetes.Interface) v1beta1.LeaseInterface {
+	return client.CoordinationV1beta1().Leases(corev1.NamespaceNodeLease)
+}

--- a/node/nodeutil/node.go
+++ b/node/nodeutil/node.go
@@ -1,0 +1,34 @@
+package nodeutil
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// SetNodeReady sets the node ready condition to true
+func SetNodeReady(n *corev1.Node) {
+	for i, c := range n.Status.Conditions {
+		if c.Type != "Ready" {
+			continue
+		}
+
+		c.Message = "Kubelet is ready"
+		c.Reason = "KubeletReady"
+		c.Status = corev1.ConditionTrue
+		c.LastHeartbeatTime = metav1.Now()
+		c.LastTransitionTime = metav1.Now()
+		n.Status.Conditions[i] = c
+		return
+	}
+
+	// No ready condition in node status
+	c := corev1.NodeCondition{
+		Type:               "Ready",
+		Status:             corev1.ConditionTrue,
+		Reason:             "KubeletReady",
+		Message:            "Kubelet is ready",
+		LastHeartbeatTime:  metav1.Now(),
+		LastTransitionTime: metav1.Now(),
+	}
+	n.Status.Conditions = append(n.Status.Conditions, c)
+}

--- a/test/e2e/suite.go
+++ b/test/e2e/suite.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/virtual-kubelet/virtual-kubelet/internal/test/e2e/framework"
 	"github.com/virtual-kubelet/virtual-kubelet/internal/test/suite"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/watch"
 )
 
 const defaultWatchTimeout = 2 * time.Minute
@@ -40,14 +42,33 @@ type EndToEndTestSuiteConfig struct {
 
 // Setup runs the setup function from the provider and other
 // procedures before running the test suite
-func (ts *EndToEndTestSuite) Setup() {
+func (ts *EndToEndTestSuite) Setup(t *testing.T) {
 	if err := ts.setup(); err != nil {
-		panic(err)
+		t.Fatal(err)
+	}
+
+	if _, err := f.WaitUntilPodReady(f.Namespace, f.NodeName); err != nil {
+		t.Fatal(err)
 	}
 
 	// Wait for the virtual kubelet (deployed as a pod) to become fully ready
-	if _, err := f.WaitUntilPodReady(f.Namespace, f.NodeName); err != nil {
-		panic(err)
+	if err := f.WaitUntilNodeCondition(func(ev watch.Event) (bool, error) {
+		n := ev.Object.(*corev1.Node)
+		if n.Name != f.NodeName {
+			return false, nil
+		}
+
+		for _, c := range n.Status.Conditions {
+			if c.Type != "Ready" {
+				continue
+			}
+			t.Log(c.Status)
+			return c.Status == corev1.ConditionTrue, nil
+		}
+
+		return false, nil
+	}); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This moves pod and node controller setup to a manager object.
It can also be extended to support configuring the http service.

Related to #655 