### PR TITLE
Move node pinging to its own goroutine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	go.opencensus.io v0.21.0
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.18.4

--- a/node/mock_test.go
+++ b/node/mock_test.go
@@ -20,51 +20,6 @@ var (
 	_ PodLifecycleHandler = (*mockProvider)(nil)
 )
 
-type waitableInt struct {
-	cond *sync.Cond
-	val  int
-}
-
-func newWaitableInt() *waitableInt {
-	return &waitableInt{
-		cond: sync.NewCond(&sync.Mutex{}),
-	}
-}
-
-func (w *waitableInt) read() int {
-	defer w.cond.L.Unlock()
-	w.cond.L.Lock()
-	return w.val
-}
-
-func (w *waitableInt) until(ctx context.Context, f func(int) bool) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	go func() {
-		<-ctx.Done()
-		w.cond.Broadcast()
-	}()
-
-	w.cond.L.Lock()
-	defer w.cond.L.Unlock()
-
-	for !f(w.val) {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		w.cond.Wait()
-	}
-	return nil
-}
-
-func (w *waitableInt) increment() {
-	w.cond.L.Lock()
-	defer w.cond.L.Unlock()
-	w.val++
-	w.cond.Broadcast()
-}
-
 type mockProvider struct {
 	creates          *waitableInt
 	updates          *waitableInt

--- a/node/node_ping_controller.go
+++ b/node/node_ping_controller.go
@@ -1,0 +1,104 @@
+package node
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/virtual-kubelet/virtual-kubelet/log"
+	"github.com/virtual-kubelet/virtual-kubelet/trace"
+	"golang.org/x/sync/singleflight"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type nodePingController struct {
+	nodeProvider       NodeProvider
+	pingInterval       time.Duration
+	firstPingCompleted chan struct{}
+	pingTimeout        *time.Duration
+
+	// "Results"
+	sync.Mutex
+	result pingResult
+}
+
+type pingResult struct {
+	pingTime time.Time
+	error    error
+}
+
+func newNodePingController(node NodeProvider, pingInterval time.Duration, timeout *time.Duration) *nodePingController {
+	return &nodePingController{
+		nodeProvider:       node,
+		pingInterval:       pingInterval,
+		firstPingCompleted: make(chan struct{}),
+		pingTimeout:        timeout,
+	}
+}
+
+func (npc *nodePingController) run(ctx context.Context) {
+	const key = "key"
+	sf := &singleflight.Group{}
+
+	// 1. If the node is "stuck" and not responding to pings, we want to set the status
+	//    to that the node provider has timed out responding to pings
+	// 2. We want it so that the context is cancelled, and whatever the node might have
+	//    been stuck on uses context so it might be unstuck
+	// 3. We want to retry pinging the node, but we do not ever want more than one
+	//    ping in flight at a time.
+
+	mkContextFunc := context.WithCancel
+
+	if npc.pingTimeout != nil {
+		mkContextFunc = func(ctx2 context.Context) (context.Context, context.CancelFunc) {
+			return context.WithTimeout(ctx2, *npc.pingTimeout)
+		}
+	}
+
+	checkFunc := func(ctx context.Context) {
+		ctx, cancel := mkContextFunc(ctx)
+		defer cancel()
+		ctx, span := trace.StartSpan(ctx, "node.pingLoop")
+		defer span.End()
+		doChan := sf.DoChan(key, func() (interface{}, error) {
+			now := time.Now()
+			ctx, span := trace.StartSpan(ctx, "node.pingNode")
+			defer span.End()
+			err := npc.nodeProvider.Ping(ctx)
+			span.SetStatus(err)
+			return now, err
+		})
+
+		var pingResult pingResult
+		select {
+		case <-ctx.Done():
+			pingResult.error = ctx.Err()
+			log.G(ctx).WithError(pingResult.error).Warn("Failed to ping node due to context cancellation")
+		case result := <-doChan:
+			pingResult.error = result.Err
+			pingResult.pingTime = result.Val.(time.Time)
+		}
+
+		npc.Lock()
+		npc.result = pingResult
+		defer npc.Unlock()
+		span.SetStatus(pingResult.error)
+	}
+
+	// Run the first check manually
+	checkFunc(ctx)
+
+	close(npc.firstPingCompleted)
+
+	wait.UntilWithContext(ctx, checkFunc, npc.pingInterval)
+}
+
+func (npc *nodePingController) getResult(ctx context.Context) (*pingResult, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-npc.firstPingCompleted:
+	}
+
+	return &npc.result, nil
+}

--- a/node/waitable_int_test.go
+++ b/node/waitable_int_test.go
@@ -1,0 +1,51 @@
+package node
+
+import (
+	"context"
+	"sync"
+)
+
+type waitableInt struct {
+	cond *sync.Cond
+	val  int
+}
+
+func newWaitableInt() *waitableInt {
+	return &waitableInt{
+		cond: sync.NewCond(&sync.Mutex{}),
+	}
+}
+
+func (w *waitableInt) read() int {
+	defer w.cond.L.Unlock()
+	w.cond.L.Lock()
+	return w.val
+}
+
+func (w *waitableInt) until(ctx context.Context, f func(int) bool) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go func() {
+		<-ctx.Done()
+		w.cond.Broadcast()
+	}()
+
+	w.cond.L.Lock()
+	defer w.cond.L.Unlock()
+
+	for !f(w.val) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		w.cond.Wait()
+	}
+	return nil
+}
+
+func (w *waitableInt) increment() {
+	w.cond.L.Lock()
+	defer w.cond.L.Unlock()
+	w.val++
+	w.cond.Broadcast()
+}


### PR DESCRIPTION
This moves the job of pinging the node provider into its own
goroutine. If it takes a long time, it shouldn't slow down
leases, and vice-versa.