### PR TITLE
Support custom filter for pod event handlers

### DIFF
--- a/node/nodeutil/filter.go
+++ b/node/nodeutil/filter.go
@@ -1,0 +1,30 @@
+package nodeutil
+
+import (
+	"context"
+
+	"github.com/virtual-kubelet/virtual-kubelet/node"
+	v1 "k8s.io/api/core/v1"
+)
+
+// FilterPodsForNodeName creates an event filter function that filters pod events such that pod.Sepc.NodeName matches the provided name
+// Use the return value of this as the PodEventFilterFunc in PodControllerConfig
+func FilterPodsForNodeName(name string) node.PodEventFilterFunc {
+	return func(_ context.Context, p *v1.Pod) bool {
+		return p.Spec.NodeName == name
+	}
+}
+
+// PodFilters turns a list of pod filters into a single filter.
+// When run, each item in the list is itterated in order until the first `true` result.
+// If nothing returns true, the filter is false.
+func PodFilters(filters ...node.PodEventFilterFunc) node.PodEventFilterFunc {
+	return func(ctx context.Context, p *v1.Pod) bool {
+		for _, f := range filters {
+			if f(ctx, p) {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/node/nodeutil/filter_test.go
+++ b/node/nodeutil/filter_test.go
@@ -1,0 +1,17 @@
+package nodeutil
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/assert"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestFilterPodsForNodeName(t *testing.T) {
+	ctx := context.Background()
+	// Doesn't match pod with wrong name
+	assert.Check(t, !FilterPodsForNodeName(t.Name())(ctx, &v1.Pod{Spec: v1.PodSpec{NodeName: "NotOurNode"}}))
+	// Match pod with wrong name
+	assert.Check(t, FilterPodsForNodeName(t.Name())(ctx, &v1.Pod{Spec: v1.PodSpec{NodeName: t.Name()}}))
+}


### PR DESCRIPTION
This allows users who have a shared informer that is *not* filtering on
node name to supply a filter for event handlers to ensure events do not
fire for pods not scheduled to the node.