### PR TITLE
Delete and recreate lease on conflict

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -424,7 +424,8 @@ func ensureLease(ctx context.Context, leases v1beta1.LeaseInterface, lease *coor
 		case errors.IsNotFound(err):
 			log.G(ctx).WithError(err).Info("Node lease not supported")
 			return nil, err
-		case errors.IsAlreadyExists(err):
+		case errors.IsAlreadyExists(err), errors.IsConflict(err):
+			log.G(ctx).WithError(err).Warn("Error creating lease, deleting and recreating")
 			if err := leases.Delete(ctx, lease.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
 				log.G(ctx).WithError(err).Error("could not delete old node lease")
 				return nil, pkgerrors.Wrap(err, "old lease exists but could not delete it")


### PR DESCRIPTION
This takes a somewhat hamfisted approach at dealing with lease
conflicts. This can happen if "someone" changes the lease underneath
us. Again, this should happen rarely, but it can happen (And does
happen in production systems).

Signed-off-by: Sargun Dhillon <sargun@sargun.me>