### PR TITLE
Fix node ping interval code / default setting code

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -82,6 +82,14 @@ func NewNodeController(p NodeProvider, node *corev1.Node, nodes v1.NodeInterface
 			return nil, pkgerrors.Wrap(err, "error applying node option")
 		}
 	}
+
+	if n.pingInterval == time.Duration(0) {
+		n.pingInterval = DefaultPingInterval
+	}
+	if n.statusInterval == time.Duration(0) {
+		n.statusInterval = DefaultStatusUpdateInterval
+	}
+
 	n.nodePingController = newNodePingController(n.p, n.pingInterval, n.pingTimeout)
 
 	return n, nil
@@ -206,13 +214,6 @@ const (
 // periodically), otherwise it will only use node status update with the configured
 // ping interval.
 func (n *NodeController) Run(ctx context.Context) error {
-	if n.pingInterval == time.Duration(0) {
-		n.pingInterval = DefaultPingInterval
-	}
-	if n.statusInterval == time.Duration(0) {
-		n.statusInterval = DefaultStatusUpdateInterval
-	}
-
 	n.chStatusUpdate = make(chan *corev1.Node, 1)
 	n.p.NotifyNodeStatus(ctx, func(node *corev1.Node) {
 		n.chStatusUpdate <- node

--- a/node/node_ping_controller.go
+++ b/node/node_ping_controller.go
@@ -28,6 +28,14 @@ type pingResult struct {
 }
 
 func newNodePingController(node NodeProvider, pingInterval time.Duration, timeout *time.Duration) *nodePingController {
+	if pingInterval == 0 {
+		panic("Node ping interval is 0")
+	}
+
+	if timeout != nil && *timeout == 0 {
+		panic("Node ping timeout is 0")
+	}
+
 	return &nodePingController{
 		nodeProvider:       node,
 		pingInterval:       pingInterval,


### PR DESCRIPTION
Change the place where we set the defaults for node ping
and node status interval. This problem manifested itself
by the node ping interval being 0 when it was set to
the default.

This makes two changes:
1. Invalid ping values, and ping timeouts will not
   allow VK to start up
2. We set the default values very early on in creation
   of the node controller -- where all the other values
   are set.

Signed-off-by: Sargun Dhillon <sargun@sargun.me>