### PR TITLE
Create stronger separation between provider node and server node

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -208,10 +208,10 @@ func TestNodeCustomUpdateStatusErrorHandler(t *testing.T) {
 	case <-node.Ready():
 	}
 
-	err = nodes.Delete(ctx, node.n.Name, metav1.DeleteOptions{})
+	err = nodes.Delete(ctx, node.serverNode.Name, metav1.DeleteOptions{})
 	assert.NilError(t, err)
 
-	testP.triggerStatusUpdate(node.n.DeepCopy())
+	testP.triggerStatusUpdate(node.serverNode.DeepCopy())
 
 	timer = time.NewTimer(10 * time.Second)
 	defer timer.Stop()


### PR DESCRIPTION
There were some (additional) bugs that were easy-ish to introduce
by interleaving the provider provided node, and the server provided
updated node. This removes the chance of that confusion.