### PR TITLE
Bug: when initialzing vk, use empty clientcmd.ConfigOverrides instead of nil

### DIFF
--- a/node/nodeutil/client.go
+++ b/node/nodeutil/client.go
@@ -29,7 +29,7 @@ func ClientsetFromEnv(kubeConfigPath string) (*kubernetes.Clientset, error) {
 		} else {
 			config, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 				&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeConfigPath},
-				nil,
+				&clientcmd.ConfigOverrides{},
 			).ClientConfig()
 		}
 	} else {


### PR DESCRIPTION
The `NewNonInteractiveClientConfig`(`k8s.io/client-go@v0.18.4/tools/clientcmd/merged_client_builder.go`)  will be called inside the `ClientConfig()`(line 33), whose second argument is `config.overrides.CurrentContext`. Using `nil` here will cause `nil pointer dereference` runtime error. 