### PR TITLE
Enable all linters by default

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,6 @@ linter-settings:
     line-length: 200
 
 linters:
-  disable-all: true
   enable:
     - errcheck
     - govet

--- a/cmd/virtual-kubelet/internal/commands/providers/provider.go
+++ b/cmd/virtual-kubelet/internal/commands/providers/provider.go
@@ -47,7 +47,6 @@ func NewCommand(s *provider.Store) *cobra.Command {
 				}
 				fmt.Fprintln(cmd.OutOrStdout(), args[0])
 			}
-			return
 		},
 	}
 }

--- a/cmd/virtual-kubelet/internal/commands/root/tracing_register_jaeger.go
+++ b/cmd/virtual-kubelet/internal/commands/root/tracing_register_jaeger.go
@@ -40,7 +40,7 @@ func NewJaegerExporter(opts TracingExporterOptions) (trace.Exporter, error) {
 		},
 	}
 
-	if jOpts.Endpoint == "" && jOpts.AgentEndpoint == "" {
+	if jOpts.Endpoint == "" && jOpts.AgentEndpoint == "" { // nolint:staticcheck
 		return nil, errors.New("Must specify either JAEGER_ENDPOINT or JAEGER_AGENT_ENDPOINT")
 	}
 

--- a/cmd/virtual-kubelet/internal/provider/mock/mock.go
+++ b/cmd/virtual-kubelet/internal/provider/mock/mock.go
@@ -329,7 +329,7 @@ func (p *MockProvider) GetPods(ctx context.Context) ([]*v1.Pod, error) {
 }
 
 func (p *MockProvider) ConfigureNode(ctx context.Context, n *v1.Node) {
-	ctx, span := trace.StartSpan(ctx, "mock.ConfigureNode") //nolint:ineffassign
+	ctx, span := trace.StartSpan(ctx, "mock.ConfigureNode") // nolint:staticcheck,ineffassign
 	defer span.End()
 
 	n.Status.Capacity = p.capacity()
@@ -429,7 +429,7 @@ func (p *MockProvider) nodeDaemonEndpoints() v1.NodeDaemonEndpoints {
 // GetStatsSummary returns dummy stats for all pods known by this provider.
 func (p *MockProvider) GetStatsSummary(ctx context.Context) (*stats.Summary, error) {
 	var span trace.Span
-	ctx, span = trace.StartSpan(ctx, "GetStatsSummary") //nolint: ineffassign
+	ctx, span = trace.StartSpan(ctx, "GetStatsSummary") //nolint: ineffassign,staticcheck
 	defer span.End()
 
 	// Grab the current timestamp so we can report it as the time the stats were generated.

--- a/internal/podutils/env.go
+++ b/internal/podutils/env.go
@@ -108,7 +108,7 @@ func populateContainerEnvironment(ctx context.Context, pod *corev1.Pod, containe
 	// https://github.com/kubernetes/kubernetes/blob/v1.13.1/pkg/kubelet/kubelet_pods.go#L557-L558
 	container.EnvFrom = []corev1.EnvFromSource{}
 
-	res := make([]corev1.EnvVar, 0)
+	res := make([]corev1.EnvVar, 0, len(tmpEnv))
 
 	for key, val := range tmpEnv {
 		res = append(res, corev1.EnvVar{
@@ -171,7 +171,7 @@ func getServiceEnvVarMap(rm *manager.ResourceManager, ns string, enableServiceLi
 // makeEnvironmentMapBasedOnEnvFrom returns a map representing the resolved environment of the specified container after being populated from the entries in the ".envFrom" field.
 func makeEnvironmentMapBasedOnEnvFrom(ctx context.Context, pod *corev1.Pod, container *corev1.Container, rm *manager.ResourceManager, recorder record.EventRecorder) (map[string]string, error) {
 	// Create a map to hold the resulting environment.
-	res := make(map[string]string, 0)
+	res := make(map[string]string)
 	// Iterate over "envFrom" references in order to populate the environment.
 loop:
 	for _, envFrom := range container.EnvFrom {

--- a/node/podcontroller.go
+++ b/node/podcontroller.go
@@ -629,7 +629,6 @@ func (pc *PodController) deleteDanglingPods(ctx context.Context, threadiness int
 
 	// Wait for all pods to be deleted.
 	wg.Wait()
-	return
 }
 
 // loggablePodName returns the "namespace/name" key for the specified pod.

--- a/trace/opencensus/opencensus_test.go
+++ b/trace/opencensus/opencensus_test.go
@@ -15,13 +15,8 @@
 package opencensus
 
 import (
-	"testing"
-
 	"github.com/virtual-kubelet/virtual-kubelet/trace"
 )
 
-func TestTracerImplementsTracer(t *testing.T) {
-	// ensure that Adapter implements trace.Tracer
-	if tt := trace.Tracer(Adapter{}); tt == nil {
-	}
-}
+// ensure that Adapter implements trace.Tracer
+var _ trace.Tracer = (*Adapter)(nil)


### PR DESCRIPTION
This removes the directive from .golangci.yml to disable all linters,
and fixes the relevant bugs / issues that are exposed.