### PR TITLE
Move v1beta1 lease controller

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,3 @@ issues:
   exclude:
     # EXC0001 errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
     - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
-
-    # EXC0003 golint: False positive when tests are defined in package 'test'
-    - func name will be used as test\.Test.* by other packages, and that stutters; consider calling this

--- a/cmd/virtual-kubelet/internal/provider/mock/mock.go
+++ b/cmd/virtual-kubelet/internal/provider/mock/mock.go
@@ -42,7 +42,7 @@ var (
 */
 
 // MockProvider implements the virtual-kubelet provider interface and stores pods in memory.
-type MockProvider struct {
+type MockProvider struct { // nolint:golint
 	nodeName           string
 	operatingSystem    string
 	internalIP         string
@@ -54,7 +54,7 @@ type MockProvider struct {
 }
 
 // MockConfig contains a mock virtual-kubelet's configurable parameters.
-type MockConfig struct {
+type MockConfig struct { // nolint:golint
 	CPU    string `json:"cpu,omitempty"`
 	Memory string `json:"memory,omitempty"`
 	Pods   string `json:"pods,omitempty"`

--- a/node/node.go
+++ b/node/node.go
@@ -22,6 +22,7 @@ import (
 	pkgerrors "github.com/pkg/errors"
 	"github.com/virtual-kubelet/virtual-kubelet/log"
 	"github.com/virtual-kubelet/virtual-kubelet/trace"
+	vktypes "github.com/virtual-kubelet/virtual-kubelet/types"
 	coord "k8s.io/api/coordination/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -41,26 +42,7 @@ const (
 	virtualKubeletLastNodeAppliedObjectMeta = "virtual-kubelet.io/last-applied-object-meta"
 )
 
-// NodeProvider is the interface used for registering a node and updating its
-// status in Kubernetes.
-//
-// Note: Implementers can choose to manage a node themselves, in which case
-// it is not needed to provide an implementation for this interface.
-type NodeProvider interface { // nolint:golint
-	// Ping checks if the node is still active.
-	// This is intended to be lightweight as it will be called periodically as a
-	// heartbeat to keep the node marked as ready in Kubernetes.
-	Ping(context.Context) error
-
-	// NotifyNodeStatus is used to asynchronously monitor the node.
-	// The passed in callback should be called any time there is a change to the
-	// node's status.
-	// This will generally trigger a call to the Kubernetes API server to update
-	// the status.
-	//
-	// NotifyNodeStatus should not block callers.
-	NotifyNodeStatus(ctx context.Context, cb func(*corev1.Node))
-}
+type NodeProvider = vktypes.NodeProvider //nolint:golint
 
 // NewNodeController creates a new node controller.
 // This does not have any side-effects on the system or kubernetes.
@@ -70,7 +52,7 @@ type NodeProvider interface { // nolint:golint
 //
 // Note: When if there are multiple NodeControllerOpts which apply against the same
 // underlying options, the last NodeControllerOpt will win.
-func NewNodeController(p NodeProvider, node *corev1.Node, nodes v1.NodeInterface, opts ...NodeControllerOpt) (*NodeController, error) {
+func NewNodeController(p vktypes.NodeProvider, node *corev1.Node, nodes v1.NodeInterface, opts ...NodeControllerOpt) (*NodeController, error) {
 	n := &NodeController{
 		p:          p,
 		serverNode: node,
@@ -174,8 +156,8 @@ type ErrorHandler func(context.Context, error) error
 // NodeController deals with creating and managing a node object in Kubernetes.
 // It can register a node with Kubernetes and periodically update its status.
 // NodeController manages a single node entity.
-type NodeController struct { // nolint:golint
-	p NodeProvider
+type NodeController struct { // nolint: golint
+	p vktypes.NodeProvider
 
 	// serverNode should only be written to on initialization, or as the result of node creation.
 	serverNode *corev1.Node

--- a/node/node.go
+++ b/node/node.go
@@ -46,7 +46,7 @@ const (
 //
 // Note: Implementers can choose to manage a node themselves, in which case
 // it is not needed to provide an implementation for this interface.
-type NodeProvider interface {
+type NodeProvider interface { // nolint:golint
 	// Ping checks if the node is still active.
 	// This is intended to be lightweight as it will be called periodically as a
 	// heartbeat to keep the node marked as ready in Kubernetes.
@@ -96,7 +96,7 @@ func NewNodeController(p NodeProvider, node *corev1.Node, nodes v1.NodeInterface
 }
 
 // NodeControllerOpt are the functional options used for configuring a node
-type NodeControllerOpt func(*NodeController) error
+type NodeControllerOpt func(*NodeController) error // nolint:golint
 
 // WithNodeEnableLeaseV1Beta1 enables support for v1beta1 leases.
 // If client is nil, leases will not be enabled.
@@ -174,7 +174,7 @@ type ErrorHandler func(context.Context, error) error
 // NodeController deals with creating and managing a node object in Kubernetes.
 // It can register a node with Kubernetes and periodically update its status.
 // NodeController manages a single node entity.
-type NodeController struct {
+type NodeController struct { // nolint:golint
 	p NodeProvider
 
 	// serverNode should only be written to on initialization, or as the result of node creation.

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -672,13 +672,13 @@ func TestNodePingSingleInflight(t *testing.T) {
 	assert.NilError(t, err)
 
 	start := time.Now()
-	go node.nodePingController.run(ctx)
-	firstPing, err := node.nodePingController.getResult(ctx)
+	go node.nodePingController.Run(ctx)
+	firstPing, err := node.nodePingController.GetResult(ctx)
 	assert.NilError(t, err)
 	timeTakenToCompleteFirstPing := time.Since(start)
 	assert.Assert(t, timeTakenToCompleteFirstPing < pingTimeout*5, "Time taken to complete first ping: %v", timeTakenToCompleteFirstPing)
 
-	assert.Assert(t, cmp.Error(firstPing.error, context.DeadlineExceeded.Error()))
+	assert.Assert(t, cmp.Error(firstPing.Error, context.DeadlineExceeded.Error()))
 	assert.Assert(t, is.Equal(1, calls.read()))
 	assert.Assert(t, is.Equal(0, finished.read()))
 

--- a/types/node.go
+++ b/types/node.go
@@ -1,0 +1,28 @@
+package types
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// NodeProvider is the interface used for registering a node and updating its
+// status in Kubernetes.
+//
+// Note: Implementers can choose to manage a node themselves, in which case
+// it is not needed to provide an implementation for this interface.
+type NodeProvider interface {
+	// Ping checks if the node is still active.
+	// This is intended to be lightweight as it will be called periodically as a
+	// heartbeat to keep the node marked as ready in Kubernetes.
+	Ping(context.Context) error
+
+	// NotifyNodeStatus is used to asynchronously monitor the node.
+	// The passed in callback should be called any time there is a change to the
+	// node's status.
+	// This will generally trigger a call to the Kubernetes API server to update
+	// the status.
+	//
+	// NotifyNodeStatus should not block callers.
+	NotifyNodeStatus(ctx context.Context, cb func(*corev1.Node))
+}


### PR DESCRIPTION
   
    In order to start to decompose the node package, we need
    to remove the types in order to avoid creating circular
    import depedencies. This works around breaking everyone
    but importing the type into node, and "re-exporting" it

    
    This makes reasoning about the controller interface / surface area
    easier. Eventually, we want to consume the upstream lease controller,
    and this is a step in that direction (so we can make it so that
    our API surface are looks similar to theirs.)
