### PR TITLE
Add v1 lease controller

### DIFF
--- a/node/lease_controller.go
+++ b/node/lease_controller.go
@@ -1,0 +1,257 @@
+package node
+
+import (
+	"context"
+	pkgerrors "errors"
+	"fmt"
+	"time"
+
+	"github.com/virtual-kubelet/virtual-kubelet/log"
+	"github.com/virtual-kubelet/virtual-kubelet/trace"
+	coord "k8s.io/api/coordination/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/typed/coordination/v1beta1"
+)
+
+type leaseController interface {
+	// run starts the lease controller. It blocks until context is cancelled, or if the lease cannot be established.
+	run(ctx context.Context)
+}
+
+// newV1BetaV1LeaseController creates a new lease controller.
+//
+// pingStatusFunc is a function that may block, but will be called every lease update interval, and will block updating,
+// or establishing the lease. If the pingResult has no error and the function returns without error, the lease
+// controller continues as normal. Otherwise, if it returns an error the lease controller will exit, and transition to
+// the disabled state.
+//
+// getNodeFunc is a function that should return the last node observed in API server. This could be the return from
+// a Create, or Update function, or Get the node itself. It should be non-blocking, as if it blocks, it will block
+// creation of the lease controller. It expects errors to be one of context, or an error from
+// k8s.io/apimachinery/pkg/api/errors.
+//
+// The lease controller will only exit if context is cancelled.
+func newV1BetaV1LeaseController(
+	client v1beta1.LeaseInterface,
+	lease *coord.Lease,
+	leaseRenewalInterval time.Duration,
+	pingStatusFunc func(context.Context) (*pingResult, error),
+	getNodeFunc func(context.Context) (*corev1.Node, error)) leaseController {
+
+	if leaseRenewalInterval == 0 {
+		panic("Lease renewal interval is 0")
+	}
+
+	lc := &v1Betav1LeaseController{
+		client:               client,
+		leaseRenewalInterval: leaseRenewalInterval,
+		pingStatusFunc:       pingStatusFunc,
+		getNodeFunc:          getNodeFunc,
+	}
+	if lease == nil {
+		lc.lease = &coord.Lease{}
+	} else {
+		lc.lease = lease.DeepCopy()
+	}
+
+	return lc
+}
+
+type v1Betav1LeaseController struct {
+	client               v1beta1.LeaseInterface
+	leaseRenewalInterval time.Duration
+	pingStatusFunc       func(context.Context) (*pingResult, error)
+	getNodeFunc          func(context.Context) (*corev1.Node, error)
+	lease                *coord.Lease
+}
+
+func (lc *v1Betav1LeaseController) run(ctx context.Context) {
+	ctx = log.WithLogger(ctx, log.G(ctx).WithField("leaseRenewalInterval", lc.leaseRenewalInterval))
+	for {
+		sleepTime := lc.leaseRenewalInterval
+
+		err := lc.poll(ctx)
+		if err != nil {
+			if pkgerrors.Is(err, context.Canceled) {
+				return
+			}
+
+			if seconds, delay := errors.SuggestsClientDelay(err); delay {
+				sleepTime = time.Second * time.Duration(seconds)
+			}
+			log.G(ctx).WithError(err).WithField("sleepTime", sleepTime).Warn("Failed to update lease. Retrying")
+		}
+		timer := time.NewTimer(sleepTime)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		}
+	}
+}
+
+func (lc *v1Betav1LeaseController) poll(ctx context.Context) (retErr error) {
+	ctx, span := trace.StartSpan(ctx, "v1Betav1LeaseController.poll")
+	defer span.End()
+
+	defer func() {
+		span.SetStatus(retErr)
+	}()
+
+	pr, err := lc.pingStatusFunc(ctx)
+	if err != nil {
+		return fmt.Errorf("Received error when attempting to ascertain node status: %w", err)
+	}
+
+	if pr.error != nil {
+		return newNodeNodeReady(pr)
+	}
+
+	lc.lease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
+	// This is 25 due to historical reasons. It was supposed to be * 5, but...reasons
+	d := int32(lc.leaseRenewalInterval.Seconds()) * 25
+	lc.lease.Spec.LeaseDurationSeconds = &d
+
+	serverNode, err := lc.getNodeFunc(ctx)
+	if err != nil {
+		return err
+	}
+	if serverNode == nil {
+		return pkgerrors.New("servernode is null")
+	}
+
+	if lc.lease.Name == "" {
+		lc.lease.Name = serverNode.Name
+	}
+
+	if lc.lease.Spec.HolderIdentity == nil {
+		name := serverNode.Name
+		lc.lease.Spec.HolderIdentity = &name
+	}
+
+	setOwnerReference(ctx, lc.lease, serverNode)
+	ctx = span.WithFields(ctx, log.Fields{
+		"lease.name": lc.lease.Name,
+		"lease.time": lc.lease.Spec.RenewTime,
+	})
+
+	// This means the lease hasn't been created before in the API Server.
+	if lc.lease.UID == "" {
+	retry:
+		l, err := lc.client.Create(ctx, lc.lease, metav1.CreateOptions{})
+		if err != nil {
+			log.G(ctx).WithError(err).Error("Failed to create new lease")
+			// The node might have been running before. Try to recreate the lease.
+			if errors.IsAlreadyExists(err) || errors.IsConflict(err) {
+				log.G(ctx).WithError(err).Warn("Error creating lease, deleting and recreating")
+				err = lc.client.Delete(ctx, lc.lease.Name, metav1.DeleteOptions{})
+				if err != nil && !errors.IsNotFound(err) {
+					log.G(ctx).WithError(err).Error("could not delete old node lease")
+					return err
+				}
+				log.G(ctx).Info("Existing lease deleted, sleeping and retrying to create lease")
+				sleep := time.NewTimer(100 * time.Millisecond)
+				defer sleep.Stop()
+				select {
+				case <-sleep.C:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+				goto retry
+			}
+			return err
+		}
+
+		log.G(ctx).WithField("lease", l).Info("Created new lease")
+		lc.lease = l
+		return nil
+	}
+
+	// This has the error behaviour that if we run into a conflict, we will not delete the lease server side,
+	// this behaviour will be fixed in the V1 Lease controller.
+	newLease, err := lc.client.Update(ctx, lc.lease, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	lc.lease = newLease
+	return nil
+}
+
+func setOwnerReference(ctx context.Context, lease *coord.Lease, serverNode *corev1.Node) {
+	// Copied and pasted from: https://github.com/kubernetes/kubernetes/blob/442a69c3bdf6fe8e525b05887e57d89db1e2f3a5/pkg/kubelet/nodelease/controller.go#L213-L216
+	// Setting owner reference needs node's UID. Note that it is different from
+	// kubelet.nodeRef.UID. When lease is initially created, it is possible that
+	// the connection between master and node is not ready yet. So try to set
+	// owner reference every time when renewing the lease, until successful.
+	//
+	// We have a special case to deal with in the node may be deleted and
+	// come back with a different UID. In this case the lease object should
+	// be deleted due to a owner reference cascading deletion, and when we renew
+	// lease again updateNodeLease will call ensureLease, and establish a new
+	// lease with the right node ID
+	if l := len(lease.OwnerReferences); l == 0 {
+		lease.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion: corev1.SchemeGroupVersion.WithKind("Node").Version,
+				Kind:       corev1.SchemeGroupVersion.WithKind("Node").Kind,
+				Name:       serverNode.Name,
+				UID:        serverNode.UID,
+			},
+		}
+	} else if l > 0 {
+		var foundAnyNode bool
+		for _, ref := range lease.OwnerReferences {
+			if ref.APIVersion == corev1.SchemeGroupVersion.WithKind("Node").Version && ref.Kind == corev1.SchemeGroupVersion.WithKind("Node").Kind {
+				foundAnyNode = true
+				if serverNode.UID == ref.UID && serverNode.Name == ref.Name {
+					return
+				}
+
+				log.G(ctx).WithFields(map[string]interface{}{
+					"node.UID":  serverNode.UID,
+					"ref.UID":   ref.UID,
+					"node.Name": serverNode.Name,
+					"ref.Name":  ref.Name,
+				}).Warn("Found that lease had node in owner references that is not this node")
+			}
+		}
+		if !foundAnyNode {
+			log.G(ctx).WithField("ownerReferences", lease.OwnerReferences).Warn("Found that lease had owner references, but no nodes in owner references")
+		}
+	}
+}
+
+// nodeNodeReadyError indicates that the node was not ready
+type nodeNodeReadyError struct {
+	pingResult *pingResult
+}
+
+func newNodeNodeReady(pingResult *pingResult) error {
+	return &nodeNodeReadyError{
+		pingResult: pingResult,
+	}
+}
+
+func (e *nodeNodeReadyError) Unwrap() error {
+	return e.pingResult.error
+}
+
+func (e *nodeNodeReadyError) Is(target error) bool {
+	_, ok := target.(*nodeNodeReadyError)
+	return ok
+}
+
+func (e *nodeNodeReadyError) As(target error) bool {
+	val, ok := target.(*nodeNodeReadyError)
+	if ok {
+		*val = *e
+	}
+	return ok
+}
+
+func (e *nodeNodeReadyError) Error() string {
+	return fmt.Sprintf("New node not ready error: %s", e.pingResult.error)
+}

--- a/node/lease_controller_test.go
+++ b/node/lease_controller_test.go
@@ -1,0 +1,13 @@
+package node
+
+import (
+	"errors"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestNotReadyError(t *testing.T) {
+	n := newNodeNodeReady(nil)
+	assert.Assert(t, errors.Is(n, &nodeNodeReadyError{}))
+}

--- a/node/lease_controller_v1.go
+++ b/node/lease_controller_v1.go
@@ -1,0 +1,309 @@
+package node
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/virtual-kubelet/virtual-kubelet/log"
+	"github.com/virtual-kubelet/virtual-kubelet/trace"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coordclientset "k8s.io/client-go/kubernetes/typed/coordination/v1"
+	"k8s.io/utils/clock"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	// renewIntervalFraction is the fraction of lease duration to renew the lease
+	renewIntervalFraction = 0.25
+	// maxUpdateRetries is the number of immediate, successive retries the Kubelet will attempt
+	// when renewing the lease before it waits for the renewal interval before trying again,
+	// similar to what we do for node status retries
+	maxUpdateRetries = 5
+	// maxBackoff is the maximum sleep time during backoff (e.g. in backoffEnsureLease)
+	maxBackoff = 7 * time.Second
+)
+
+type controller struct {
+	leaseClient          coordclientset.LeaseInterface
+	leaseDurationSeconds int32
+	renewInterval        time.Duration
+	clock                clock.Clock
+	pingStatusFunc       func(context.Context) (*pingResult, error)
+	getNodeFunc          func(context.Context) (*corev1.Node, error)
+
+	// latestLease is the latest node lease which Kubelet updated or created
+	latestLease *coordinationv1.Lease
+}
+
+// newController constructs and returns a controller
+func newController(
+	clock clock.Clock,
+	client coordclientset.LeaseInterface,
+	leaseDurationSeconds int32,
+	pingStatusFunc func(context.Context) (*pingResult, error),
+	getNodeFunc func(context.Context) (*corev1.Node, error)) leaseController {
+
+	leaseDuration := time.Duration(leaseDurationSeconds) * time.Second
+	renewInterval := time.Duration(float64(leaseDuration) * renewIntervalFraction)
+	return newControllerWithRenewInterval(
+		clock,
+		client,
+		leaseDurationSeconds,
+		renewInterval,
+		pingStatusFunc,
+		getNodeFunc)
+}
+
+// newControllerWithRenewInterval constructs and returns a v1 lease controller
+func newControllerWithRenewInterval(
+	clock clock.Clock,
+	client coordclientset.LeaseInterface,
+	leaseDurationSeconds int32,
+	renewInterval time.Duration,
+	pingStatusFunc func(context.Context) (*pingResult, error),
+	getNodeFunc func(context.Context) (*corev1.Node, error)) leaseController {
+
+	return &controller{
+		leaseClient:          client,
+		leaseDurationSeconds: leaseDurationSeconds,
+		renewInterval:        renewInterval,
+		clock:                clock,
+		pingStatusFunc:       pingStatusFunc,
+		getNodeFunc:          getNodeFunc,
+	}
+}
+
+// Run runs the controller
+func (c *controller) run(ctx context.Context) {
+	if c.leaseClient == nil {
+		log.G(ctx).Infof("node lease controller has nil lease client, will not claim or renew leases")
+		return
+	}
+	c.sync(ctx)
+	wait.UntilWithContext(ctx, c.sync, c.renewInterval)
+}
+
+func (c *controller) sync(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var err error
+	ctx, span := trace.StartSpan(ctx, "controller.sync")
+	defer span.End()
+
+	pingResult, err := c.pingStatusFunc(ctx)
+	if err != nil {
+		log.G(ctx).WithError(err).Error("Could not get ping status")
+	}
+	if pingResult.error != nil {
+		log.G(ctx).WithError(pingResult.error).Error("Ping result is not clean, not updating lease")
+	}
+
+	node, err := c.getNodeFunc(ctx)
+	if err != nil {
+		log.G(ctx).WithError(err).Error("Could not get server node")
+		span.SetStatus(err)
+		return
+	}
+	if node == nil {
+		err = errors.New("Servernode is null")
+		log.G(ctx).WithError(err).Error("servernode is null")
+		span.SetStatus(err)
+		return
+	}
+
+	if c.latestLease != nil {
+		// As long as node lease is not (or very rarely) updated by any other agent than Kubelet,
+		// we can optimistically assume it didn't change since our last update and try updating
+		// based on the version from that time. Thanks to it we avoid GET call and reduce load
+		// on etcd and kube-apiserver.
+		// If at some point other agents will also be frequently updating the Lease object, this
+		// can result in performance degradation, because we will end up with calling additional
+		// GET/PUT - at this point this whole "if" should be removed.
+		err := c.retryUpdateLease(ctx, node, c.newLease(ctx, node, c.latestLease))
+		if err == nil {
+			span.SetStatus(err)
+			return
+		}
+		log.G(ctx).WithError(err).Info("failed to update lease using latest lease, fallback to ensure lease")
+	}
+
+	lease, created := c.backoffEnsureLease(ctx, node)
+	c.latestLease = lease
+	// we don't need to update the lease if we just created it
+	if !created && lease != nil {
+		if err := c.retryUpdateLease(ctx, node, lease); err != nil {
+			log.G(ctx).WithError(err).WithField("renewInterval", c.renewInterval).Errorf("Will retry after")
+			span.SetStatus(err)
+		}
+	}
+}
+
+// backoffEnsureLease attempts to create the lease if it does not exist,
+// and uses exponentially increasing waits to prevent overloading the API server
+// with retries. Returns the lease, and true if this call created the lease,
+// false otherwise.
+func (c *controller) backoffEnsureLease(ctx context.Context, node *corev1.Node) (*coordinationv1.Lease, bool) {
+	ctx, span := trace.StartSpan(ctx, "controller.backoffEnsureLease")
+	defer span.End()
+
+	var (
+		lease   *coordinationv1.Lease
+		created bool
+		err     error
+	)
+	sleep := 100 * time.Millisecond
+	for {
+		lease, created, err = c.ensureLease(ctx, node)
+		if err == nil {
+			break
+		}
+		sleep = minDuration(2*sleep, maxBackoff)
+		log.G(ctx).WithError(err).Errorf("failed to ensure node lease exists, will retry in %v", sleep)
+		// backoff wait
+		c.clock.Sleep(sleep)
+		timer := c.clock.NewTimer(sleep)
+		defer timer.Stop()
+		select {
+		case <-timer.C():
+		case <-ctx.Done():
+			return nil, false
+		}
+	}
+	return lease, created
+}
+
+// ensureLease creates the lease if it does not exist. Returns the lease and
+// a bool (true if this call created the lease), or any error that occurs.
+func (c *controller) ensureLease(ctx context.Context, node *corev1.Node) (*coordinationv1.Lease, bool, error) {
+	ctx, span := trace.StartSpan(ctx, "controller.ensureLease")
+	defer span.End()
+
+	lease, err := c.leaseClient.Get(ctx, node.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		// lease does not exist, create it.
+		leaseToCreate := c.newLease(ctx, node, nil)
+		if len(leaseToCreate.OwnerReferences) == 0 {
+			// We want to ensure that a lease will always have OwnerReferences set.
+			// Thus, given that we weren't able to set it correctly, we simply
+			// not create it this time - we will retry in the next iteration.
+			return nil, false, nil
+		}
+		lease, err := c.leaseClient.Create(ctx, leaseToCreate, metav1.CreateOptions{})
+		if err != nil {
+			span.SetStatus(err)
+			return nil, false, err
+		}
+		log.G(ctx).Debug("Successfully created lease")
+		return lease, true, nil
+	} else if err != nil {
+		// unexpected error getting lease
+		log.G(ctx).WithError(err).Error("Unexpected error getting lease")
+		span.SetStatus(err)
+		return nil, false, err
+	}
+	log.G(ctx).Debug("Successfully recovered existing lease")
+	// lease already existed
+	return lease, false, nil
+}
+
+// retryUpdateLease attempts to update the lease for maxUpdateRetries,
+// call this once you're sure the lease has been created
+func (c *controller) retryUpdateLease(ctx context.Context, node *corev1.Node, base *coordinationv1.Lease) error {
+	ctx, span := trace.StartSpan(ctx, "controller.retryUpdateLease")
+	defer span.End()
+
+	for i := 0; i < maxUpdateRetries; i++ {
+		lease, err := c.leaseClient.Update(ctx, c.newLease(ctx, node, base), metav1.UpdateOptions{})
+		if err == nil {
+			log.G(ctx).WithField("retries", i).Debug("Successfully updated lease")
+			c.latestLease = lease
+			return nil
+		}
+		log.G(ctx).WithError(err).Error("failed to update node lease")
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			break
+		}
+		// OptimisticLockError requires getting the newer version of lease to proceed.
+		if apierrors.IsConflict(err) {
+			base, _ = c.backoffEnsureLease(ctx, node)
+			continue
+		}
+	}
+	err := fmt.Errorf("failed %d attempts to update node lease", maxUpdateRetries)
+	span.SetStatus(err)
+	return err
+}
+
+// newLease constructs a new lease if base is nil, or returns a copy of base
+// with desired state asserted on the copy.
+func (c *controller) newLease(ctx context.Context, node *corev1.Node, base *coordinationv1.Lease) *coordinationv1.Lease {
+	ctx, span := trace.StartSpan(ctx, "controller.newLease")
+	defer span.End()
+	// Use the bare minimum set of fields; other fields exist for debugging/legacy,
+	// but we don't need to make node heartbeats more complicated by using them.
+	var lease *coordinationv1.Lease
+	if base == nil {
+		lease = &coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      node.Name,
+				Namespace: corev1.NamespaceNodeLease,
+			},
+			Spec: coordinationv1.LeaseSpec{
+				HolderIdentity:       pointer.StringPtr(node.Name),
+				LeaseDurationSeconds: pointer.Int32Ptr(c.leaseDurationSeconds),
+			},
+		}
+	} else {
+		lease = base.DeepCopy()
+	}
+	lease.Spec.RenewTime = &metav1.MicroTime{Time: c.clock.Now()}
+
+	// Setting owner reference needs node's UID. Note that it is different from
+	// kubelet.nodeRef.UID. When lease is initially created, it is possible that
+	// the connection between master and node is not ready yet. So try to set
+	// owner reference every time when renewing the lease, until successful.
+	if len(lease.OwnerReferences) == 0 {
+		lease.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion: corev1.SchemeGroupVersion.WithKind("Node").Version,
+				Kind:       corev1.SchemeGroupVersion.WithKind("Node").Kind,
+				Name:       node.Name,
+				UID:        node.UID,
+			},
+		}
+	}
+
+	ctx = span.WithFields(ctx, map[string]interface{}{
+		"lease": lease,
+	})
+	log.G(ctx).Debug("Generated lease")
+	return lease
+}
+
+func minDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/node/node.go
+++ b/node/node.go
@@ -17,6 +17,8 @@ package node
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sync"
 	"time"
 
 	pkgerrors "github.com/pkg/errors"
@@ -39,6 +41,12 @@ const (
 	// the three-way patch
 	virtualKubeletLastNodeAppliedNodeStatus = "virtual-kubelet.io/last-applied-node-status"
 	virtualKubeletLastNodeAppliedObjectMeta = "virtual-kubelet.io/last-applied-object-meta"
+)
+
+var (
+	// ErrConflictingLeaseControllerConfiguration is returned when the lease controller related options have been
+	// specified multiple times
+	ErrConflictingLeaseControllerConfiguration = pkgerrors.New("Multiple, conflicting lease configurations have been put into place")
 )
 
 // NodeProvider is the interface used for registering a node and updating its
@@ -91,6 +99,9 @@ func NewNodeController(p NodeProvider, node *corev1.Node, nodes v1.NodeInterface
 	}
 
 	n.nodePingController = newNodePingController(n.p, n.pingInterval, n.pingTimeout)
+	if n.leaseControllerProvider != nil {
+		n.leaseController = n.leaseControllerProvider(n.pingInterval)
+	}
 
 	return n, nil
 }
@@ -107,15 +118,25 @@ type NodeControllerOpt func(*NodeController) error // nolint:golint
 // See WithNodePingInterval().
 //
 // This also affects the frequency of node status updates:
-//   - When leases are *not* enabled (or are disabled due to no support on the cluster)
-//     the node status is updated at every ping interval.
+//   - When leases are *not* enabled the node status is updated at every ping interval.
 //   - When node leases are enabled, node status updates are controlled by the
 //     node status update interval option.
 // To set a custom node status update interval, see WithNodeStatusUpdateInterval().
 func WithNodeEnableLeaseV1Beta1(client v1beta1.LeaseInterface, baseLease *coord.Lease) NodeControllerOpt {
 	return func(n *NodeController) error {
-		n.leases = client
-		n.lease = baseLease
+		if n.leaseControllerProvider != nil {
+			return ErrConflictingLeaseControllerConfiguration
+		}
+
+		n.leaseControllerProvider = func(leaseRenewalInterval time.Duration) leaseController {
+			return newV1BetaV1LeaseController(
+				client,
+				baseLease,
+				leaseRenewalInterval,
+				n.nodePingController.getResult,
+				n.getServerNode)
+		}
+
 		return nil
 	}
 }
@@ -177,16 +198,18 @@ type ErrorHandler func(context.Context, error) error
 type NodeController struct { // nolint:golint
 	p NodeProvider
 
-	// serverNode should only be written to on initialization, or as the result of node creation.
-	serverNode *corev1.Node
+	// serverNode must be updated each time it is updated in API Server
+	serverNodeLock sync.Mutex
+	serverNode     *corev1.Node
+	nodes          v1.NodeInterface
 
-	leases v1beta1.LeaseInterface
-	nodes  v1.NodeInterface
+	// To be set by the config options. The lease controller depends on the node ping controller, and therefore
+	// should be created *after* the node ping controller
+	leaseControllerProvider func(leaseRenewalInterval time.Duration) leaseController
+	leaseController         leaseController
 
-	disableLease   bool
 	pingInterval   time.Duration
 	statusInterval time.Duration
-	lease          *coord.Lease
 	chStatusUpdate chan *corev1.Node
 
 	nodeStatusUpdateErrorHandler ErrorHandler
@@ -195,6 +218,8 @@ type NodeController struct { // nolint:golint
 
 	nodePingController *nodePingController
 	pingTimeout        *time.Duration
+
+	group wait.Group
 }
 
 // The default intervals used for lease and status updates.
@@ -221,30 +246,20 @@ func (n *NodeController) Run(ctx context.Context) error {
 		n.chStatusUpdate <- node
 	})
 
+	n.group.StartWithContext(ctx, n.nodePingController.run)
+
+	n.serverNodeLock.Lock()
 	providerNode := n.serverNode.DeepCopy()
+	n.serverNodeLock.Unlock()
 
 	if err := n.ensureNode(ctx, providerNode); err != nil {
 		return err
 	}
 
-	if n.leases == nil {
-		n.disableLease = true
-		return n.controlLoop(ctx, providerNode)
+	if n.leaseController != nil {
+		n.group.StartWithContext(ctx, n.leaseController.run)
 	}
 
-	n.lease = newLease(ctx, n.lease, n.serverNode, n.pingInterval)
-
-	l, err := ensureLease(ctx, n.leases, n.lease)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return pkgerrors.Wrap(err, "error creating node lease")
-		}
-		log.G(ctx).Info("Node leases not supported, falling back to only node status updates")
-		n.disableLease = true
-	}
-	n.lease = l
-
-	log.G(ctx).Debug("Created node lease")
 	return n.controlLoop(ctx, providerNode)
 }
 
@@ -260,12 +275,17 @@ func (n *NodeController) ensureNode(ctx context.Context, providerNode *corev1.No
 		return err
 	}
 
-	node, err := n.nodes.Create(ctx, n.serverNode, metav1.CreateOptions{})
+	n.serverNodeLock.Lock()
+	serverNode := n.serverNode
+	n.serverNodeLock.Unlock()
+	node, err := n.nodes.Create(ctx, serverNode, metav1.CreateOptions{})
 	if err != nil {
 		return pkgerrors.Wrap(err, "error registering node with kubernetes")
 	}
 
+	n.serverNodeLock.Lock()
 	n.serverNode = node
+	n.serverNodeLock.Unlock()
 	// Bad things will happen if the node is deleted in k8s and recreated by someone else
 	// we rely on this persisting
 	providerNode.ObjectMeta.Name = node.Name
@@ -283,50 +303,31 @@ func (n *NodeController) Ready() <-chan struct{} {
 }
 
 func (n *NodeController) controlLoop(ctx context.Context, providerNode *corev1.Node) error {
-	pingTimer := time.NewTimer(n.pingInterval)
-	defer pingTimer.Stop()
-
-	statusTimer := time.NewTimer(n.statusInterval)
-	defer statusTimer.Stop()
-	timerResetDuration := n.statusInterval
-	if n.disableLease {
-		// when resetting the timer after processing a status update, reset it to the ping interval
-		// (since it will be the ping timer as serverNode.disableLease == true)
-		timerResetDuration = n.pingInterval
-
-		// hack to make sure this channel always blocks since we won't be using it
-		if !statusTimer.Stop() {
-			<-statusTimer.C
-		}
-	}
-
 	close(n.chReady)
 
-	group := &wait.Group{}
-	group.StartWithContext(ctx, n.nodePingController.run)
-	defer group.Wait()
+	defer n.group.Wait()
 
 	loop := func() bool {
 		ctx, span := trace.StartSpan(ctx, "node.controlLoop.loop")
 		defer span.End()
 
+		var timer *time.Timer
+		if n.leaseController == nil {
+			log.G(ctx).WithField("pingInterval", n.pingInterval).Debug("lease controller is not enabled, updating node status in Kube API server at Ping Time Interval")
+			ctx = span.WithField(ctx, "sleepTime", n.pingInterval)
+			timer = time.NewTimer(n.pingInterval)
+		} else {
+			log.G(ctx).WithField("statusInterval", n.statusInterval).Debug("lease controller in use, updating at statusInterval")
+			ctx = span.WithField(ctx, "sleepTime", n.statusInterval)
+			timer = time.NewTimer(n.statusInterval)
+		}
+		defer timer.Stop()
+
 		select {
 		case <-ctx.Done():
 			return true
 		case updated := <-n.chStatusUpdate:
-			var t *time.Timer
-			if n.disableLease {
-				t = pingTimer
-			} else {
-				t = statusTimer
-			}
-
 			log.G(ctx).Debug("Received node status update")
-			// Performing a status update so stop/reset the status update timer in this
-			// branch otherwise there could be an unnecessary status update.
-			if !t.Stop() {
-				<-t.C
-			}
 
 			providerNode.Status = updated.Status
 			providerNode.ObjectMeta.Annotations = updated.Annotations
@@ -334,19 +335,10 @@ func (n *NodeController) controlLoop(ctx context.Context, providerNode *corev1.N
 			if err := n.updateStatus(ctx, providerNode, false); err != nil {
 				log.G(ctx).WithError(err).Error("Error handling node status update")
 			}
-			t.Reset(timerResetDuration)
-		case <-statusTimer.C:
+		case <-timer.C:
 			if err := n.updateStatus(ctx, providerNode, false); err != nil {
 				log.G(ctx).WithError(err).Error("Error handling node status update")
 			}
-			statusTimer.Reset(n.statusInterval)
-		case <-pingTimer.C:
-			if err := n.handlePing(ctx, providerNode); err != nil {
-				log.G(ctx).WithError(err).Error("Error while handling node ping")
-			} else {
-				log.G(ctx).Debug("Successful node ping")
-			}
-			pingTimer.Reset(n.pingInterval)
 		}
 		return false
 	}
@@ -359,48 +351,18 @@ func (n *NodeController) controlLoop(ctx context.Context, providerNode *corev1.N
 	}
 }
 
-func (n *NodeController) handlePing(ctx context.Context, providerNode *corev1.Node) (retErr error) {
-	ctx, span := trace.StartSpan(ctx, "node.handlePing")
-	defer span.End()
-	defer func() {
-		span.SetStatus(retErr)
-	}()
-
-	result, err := n.nodePingController.getResult(ctx)
-	if err != nil {
-		err = pkgerrors.Wrap(err, "error while fetching result of node ping")
-		return err
-	}
-
-	if result.error != nil {
-		err = pkgerrors.Wrap(err, "node ping returned error on ping")
-		return err
-	}
-
-	if n.disableLease {
-		return n.updateStatus(ctx, providerNode, false)
-	}
-
-	// TODO(Sargun): Pass down the result / timestamp so we can accurately track when the ping actually occurred
-	return n.updateLease(ctx)
-}
-
-func (n *NodeController) updateLease(ctx context.Context) error {
-	l, err := updateNodeLease(ctx, n.leases, newLease(ctx, n.lease, n.serverNode, n.pingInterval))
-	if err != nil {
-		return err
-	}
-
-	n.lease = l
-	return nil
-}
-
 func (n *NodeController) updateStatus(ctx context.Context, providerNode *corev1.Node, skipErrorCb bool) (err error) {
 	ctx, span := trace.StartSpan(ctx, "node.updateStatus")
 	defer span.End()
 	defer func() {
 		span.SetStatus(err)
 	}()
+
+	if result, err := n.nodePingController.getResult(ctx); err != nil {
+		return err
+	} else if result.error != nil {
+		return fmt.Errorf("Not updating node status because node ping failed: %w", result.error)
+	}
 
 	updateNodeStatusHeartbeat(providerNode)
 
@@ -420,64 +382,20 @@ func (n *NodeController) updateStatus(ctx context.Context, providerNode *corev1.
 		}
 	}
 
+	n.serverNodeLock.Lock()
 	n.serverNode = node
+	n.serverNodeLock.Unlock()
 	return nil
 }
 
-func ensureLease(ctx context.Context, leases v1beta1.LeaseInterface, lease *coord.Lease) (*coord.Lease, error) {
-	l, err := leases.Create(ctx, lease, metav1.CreateOptions{})
-	if err != nil {
-		switch {
-		case errors.IsNotFound(err):
-			log.G(ctx).WithError(err).Info("Node lease not supported")
-			return nil, err
-		case errors.IsAlreadyExists(err), errors.IsConflict(err):
-			log.G(ctx).WithError(err).Warn("Error creating lease, deleting and recreating")
-			if err := leases.Delete(ctx, lease.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-				log.G(ctx).WithError(err).Error("could not delete old node lease")
-				return nil, pkgerrors.Wrap(err, "old lease exists but could not delete it")
-			}
-			l, err = leases.Create(ctx, lease, metav1.CreateOptions{})
-		}
+// Returns a copy of the server node object
+func (n *NodeController) getServerNode(ctx context.Context) (*corev1.Node, error) {
+	n.serverNodeLock.Lock()
+	defer n.serverNodeLock.Unlock()
+	if n.serverNode == nil {
+		return nil, pkgerrors.New("Server node does not yet exist")
 	}
-
-	return l, err
-}
-
-// updateNodeLease updates the node lease.
-//
-// If this function returns an errors.IsNotFound(err) error, this likely means
-// that node leases are not supported, if this is the case, call updateNodeStatus
-// instead.
-func updateNodeLease(ctx context.Context, leases v1beta1.LeaseInterface, lease *coord.Lease) (*coord.Lease, error) {
-	ctx, span := trace.StartSpan(ctx, "node.UpdateNodeLease")
-	defer span.End()
-
-	ctx = span.WithFields(ctx, log.Fields{
-		"lease.name": lease.Name,
-		"lease.time": lease.Spec.RenewTime,
-	})
-
-	if lease.Spec.LeaseDurationSeconds != nil {
-		ctx = span.WithField(ctx, "lease.expiresSeconds", *lease.Spec.LeaseDurationSeconds)
-	}
-
-	l, err := leases.Update(ctx, lease, metav1.UpdateOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			log.G(ctx).Debug("lease not found")
-			l, err = ensureLease(ctx, leases, lease)
-		}
-		if err != nil {
-			span.SetStatus(err)
-			return nil, err
-		}
-		log.G(ctx).Debug("created new lease")
-	} else {
-		log.G(ctx).Debug("updated lease")
-	}
-
-	return l, nil
+	return n.serverNode.DeepCopy(), nil
 }
 
 // just so we don't have to allocate this on every get request
@@ -640,77 +558,6 @@ func updateNodeStatus(ctx context.Context, nodes v1.NodeInterface, nodeFromProvi
 		WithField("node.Status.Conditions", updatedNode.Status.Conditions).
 		Debug("updated node status in api server")
 	return updatedNode, nil
-}
-
-// This will return a new lease. It will either update base lease (and the set the renewal time appropriately), or create a brand new lease
-func newLease(ctx context.Context, base *coord.Lease, serverNode *corev1.Node, leaseRenewalInterval time.Duration) *coord.Lease {
-	var lease *coord.Lease
-	if base == nil {
-		lease = &coord.Lease{}
-	} else {
-		lease = base.DeepCopy()
-	}
-
-	lease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
-
-	if lease.Spec.LeaseDurationSeconds == nil {
-		// This is 25 due to historical reasons. It was supposed to be * 5, but...reasons
-		d := int32(leaseRenewalInterval.Seconds()) * 25
-		lease.Spec.LeaseDurationSeconds = &d
-	}
-
-	if lease.Name == "" {
-		lease.Name = serverNode.Name
-	}
-	if lease.Spec.HolderIdentity == nil {
-		// Let's do a copy here
-		name := serverNode.Name
-		lease.Spec.HolderIdentity = &name
-	}
-
-	// Copied and pasted from: https://github.com/kubernetes/kubernetes/blob/442a69c3bdf6fe8e525b05887e57d89db1e2f3a5/pkg/kubelet/nodelease/controller.go#L213-L216
-	// Setting owner reference needs node's UID. Note that it is different from
-	// kubelet.nodeRef.UID. When lease is initially created, it is possible that
-	// the connection between master and node is not ready yet. So try to set
-	// owner reference every time when renewing the lease, until successful.
-	//
-	// We have a special case to deal with in the node may be deleted and
-	// come back with a different UID. In this case the lease object should
-	// be deleted due to a owner reference cascading deletion, and when we renew
-	// lease again updateNodeLease will call ensureLease, and establish a new
-	// lease with the right node ID
-	if l := len(lease.OwnerReferences); l == 0 {
-		lease.OwnerReferences = []metav1.OwnerReference{
-			{
-				APIVersion: corev1.SchemeGroupVersion.WithKind("Node").Version,
-				Kind:       corev1.SchemeGroupVersion.WithKind("Node").Kind,
-				Name:       serverNode.Name,
-				UID:        serverNode.UID,
-			},
-		}
-	} else if l > 0 {
-		var foundAnyNode bool
-		for _, ref := range lease.OwnerReferences {
-			if ref.APIVersion == corev1.SchemeGroupVersion.WithKind("Node").Version && ref.Kind == corev1.SchemeGroupVersion.WithKind("Node").Kind {
-				foundAnyNode = true
-				if serverNode.UID == ref.UID && serverNode.Name == ref.Name {
-					return lease
-				}
-
-				log.G(ctx).WithFields(map[string]interface{}{
-					"node.UID":  serverNode.UID,
-					"ref.UID":   ref.UID,
-					"node.Name": serverNode.Name,
-					"ref.Name":  ref.Name,
-				}).Warn("Found that lease had node in owner references that is not this node")
-			}
-		}
-		if !foundAnyNode {
-			log.G(ctx).Warn("Found that lease had owner references, but no nodes in owner references")
-		}
-	}
-
-	return lease
 }
 
 func updateNodeStatusHeartbeat(n *corev1.Node) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -16,6 +16,7 @@ package node
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -24,12 +25,16 @@ import (
 	"gotest.tools/assert"
 	"gotest.tools/assert/cmp"
 	is "gotest.tools/assert/cmp"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	coord "k8s.io/api/coordination/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testclient "k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -43,6 +48,20 @@ func testNodeRun(t *testing.T, enableLease bool) {
 	defer cancel()
 
 	c := testclient.NewSimpleClientset()
+	c.PrependReactor("create", "leases", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+		updateAction := action.(ktesting.CreateAction)
+		obj := updateAction.GetObject()
+		switch lease := obj.(type) {
+		case *coord.Lease:
+			lease.UID = uuid.NewUUID()
+		case *coordinationv1.Lease:
+			lease.UID = uuid.NewUUID()
+		default:
+			panic(fmt.Sprintf("Unknown object type: %T", lease))
+		}
+
+		return false, nil, nil
+	})
 
 	testP := &testNodeProvider{NodeProvider: &NaiveNodeProvider{}}
 
@@ -224,23 +243,6 @@ func TestNodeCustomUpdateStatusErrorHandler(t *testing.T) {
 	}
 }
 
-func TestEnsureLease(t *testing.T) {
-	c := testclient.NewSimpleClientset().CoordinationV1beta1().Leases(corev1.NamespaceNodeLease)
-	n := testNode(t)
-	ctx := context.Background()
-
-	lease := newLease(ctx, nil, n, 1*time.Second)
-
-	l1, err := ensureLease(ctx, c, lease.DeepCopy())
-	assert.NilError(t, err)
-	assert.Check(t, timeEqual(l1.Spec.RenewTime.Time, lease.Spec.RenewTime.Time))
-
-	l1.Spec.RenewTime.Time = time.Now().Add(1 * time.Second)
-	l2, err := ensureLease(ctx, c, l1.DeepCopy())
-	assert.NilError(t, err)
-	assert.Check(t, timeEqual(l2.Spec.RenewTime.Time, l1.Spec.RenewTime.Time))
-}
-
 func TestUpdateNodeStatus(t *testing.T) {
 	n := testNode(t)
 	n.Status.Conditions = append(n.Status.Conditions, corev1.NodeCondition{
@@ -275,53 +277,6 @@ func TestUpdateNodeStatus(t *testing.T) {
 
 	_, err = updateNodeStatus(ctx, nodes, updated.DeepCopy())
 	assert.Equal(t, errors.IsNotFound(err), true, err)
-}
-
-func TestUpdateNodeLease(t *testing.T) {
-	ctx := context.Background()
-
-	leases := testclient.NewSimpleClientset().CoordinationV1beta1().Leases(corev1.NamespaceNodeLease)
-	n := testNode(t)
-
-	lease := newLease(ctx, nil, n, time.Duration(0))
-
-	l, err := updateNodeLease(ctx, leases, lease)
-	assert.NilError(t, err)
-	assert.Equal(t, l.Name, lease.Name)
-	assert.Assert(t, cmp.DeepEqual(l.Spec.HolderIdentity, lease.Spec.HolderIdentity))
-
-	compare, err := leases.Get(ctx, l.Name, emptyGetOptions)
-	assert.NilError(t, err)
-	assert.Equal(t, l.Spec.RenewTime.Time.Unix(), compare.Spec.RenewTime.Time.Unix())
-	assert.Equal(t, compare.Name, lease.Name)
-	assert.Assert(t, cmp.DeepEqual(compare.Spec.HolderIdentity, lease.Spec.HolderIdentity))
-
-	l.Spec.RenewTime.Time = time.Now().Add(10 * time.Second)
-
-	compare, err = updateNodeLease(ctx, leases, l.DeepCopy())
-	assert.NilError(t, err)
-	assert.Equal(t, compare.Spec.RenewTime.Time.Unix(), l.Spec.RenewTime.Time.Unix())
-	assert.Equal(t, compare.Name, lease.Name)
-	assert.Assert(t, cmp.DeepEqual(compare.Spec.HolderIdentity, lease.Spec.HolderIdentity))
-}
-
-func TestFixNodeLeaseReferences(t *testing.T) {
-	ctx := context.Background()
-	n := testNode(t)
-
-	lease1 := newLease(ctx, nil, n, time.Second)
-	// Let's break owner references
-	lease1.OwnerReferences = nil
-	time.Sleep(2 * time.Nanosecond)
-	lease2 := newLease(ctx, lease1, n, time.Second)
-
-	// Make sure that newLease actually did its jobs
-	assert.Assert(t, lease2.Spec.RenewTime.Nanosecond() > lease1.Spec.RenewTime.Nanosecond())
-
-	// Let's check if owner references got set
-	assert.Assert(t, is.Len(lease2.OwnerReferences, 1))
-	assert.Assert(t, is.Equal(lease2.OwnerReferences[0].UID, n.UID))
-	assert.Assert(t, is.Equal(lease2.OwnerReferences[0].Name, n.Name))
 }
 
 // TestPingAfterStatusUpdate checks that Ping continues to be called with the specified interval
@@ -770,15 +725,6 @@ func before(x, y time.Time) cmp.Comparison {
 			return cmp.ResultSuccess
 		}
 		return cmp.ResultFailureTemplate(failTemplate(">="), map[string]interface{}{"x": x, "y": y})
-	}
-}
-
-func timeEqual(x, y time.Time) cmp.Comparison {
-	return func() cmp.Result {
-		if x.Equal(y) {
-			return cmp.ResultSuccess
-		}
-		return cmp.ResultFailureTemplate(failTemplate("!="), map[string]interface{}{"x": x, "y": y})
 	}
 }
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -38,12 +38,22 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
+type withLease int
+
+const (
+	leasenone = iota
+	leasev1beta1
+	leasev1
+)
+
 func TestNodeRun(t *testing.T) {
-	t.Run("WithoutLease", func(t *testing.T) { testNodeRun(t, false) })
-	t.Run("WithLease", func(t *testing.T) { testNodeRun(t, true) })
+	t.Run("WithoutLease", func(t *testing.T) { testNodeRun(t, leasenone) })
+	t.Run("WithLease", func(t *testing.T) { testNodeRun(t, leasev1beta1) })
+	t.Run("WithLeaseV1", func(t *testing.T) { testNodeRun(t, leasev1) })
+
 }
 
-func testNodeRun(t *testing.T, enableLease bool) {
+func testNodeRun(t *testing.T, enableLease withLease) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -67,14 +77,18 @@ func testNodeRun(t *testing.T, enableLease bool) {
 
 	nodes := c.CoreV1().Nodes()
 	leases := c.CoordinationV1beta1().Leases(corev1.NamespaceNodeLease)
+	leasesv1 := c.CoordinationV1().Leases(corev1.NamespaceNodeLease)
 
 	interval := 1 * time.Millisecond
 	opts := []NodeControllerOpt{
 		WithNodePingInterval(interval),
 		WithNodeStatusUpdateInterval(interval),
 	}
-	if enableLease {
+	if enableLease == leasev1beta1 {
 		opts = append(opts, WithNodeEnableLeaseV1Beta1(leases, nil))
+	}
+	if enableLease == leasev1 {
+		opts = append(opts, WithNodeEnableLeaseV1WithRenewInterval(leasesv1, 1, time.Millisecond))
 	}
 	testNode := testNode(t)
 	// We have to refer to testNodeCopy during the course of the test. testNode is modified by the node controller
@@ -102,8 +116,13 @@ func testNodeRun(t *testing.T, enableLease bool) {
 	defer lw.Stop()
 	lr := lw.ResultChan()
 
+	lwV1 := makeWatch(ctx, t, leasesv1, testNodeCopy.Name)
+	defer lwV1.Stop()
+	lrV1 := lwV1.ResultChan()
+
 	var (
 		lBefore      *coord.Lease
+		lv1Before    *coordinationv1.Lease
 		nodeUpdates  int
 		leaseUpdates int
 
@@ -114,6 +133,7 @@ func testNodeRun(t *testing.T, enableLease bool) {
 	timeout := time.After(30 * time.Second)
 	for i := 0; i < iters; i++ {
 		var l *coord.Lease
+		var lv1 *coordinationv1.Lease
 
 		select {
 		case <-timeout:
@@ -138,6 +158,16 @@ func testNodeRun(t *testing.T, enableLease bool) {
 			}
 
 			lBefore = l
+		case le := <-lrV1:
+			lv1 = le.Object.(*coordinationv1.Lease)
+			leaseUpdates++
+			assert.Assert(t, cmp.Equal(lv1.Spec.HolderIdentity != nil, true))
+			assert.NilError(t, err)
+			assert.Check(t, cmp.Equal(*lv1.Spec.HolderIdentity, testNodeCopy.Name))
+			if lv1Before != nil {
+				assert.Check(t, before(lv1Before.Spec.RenewTime.Time, lv1.Spec.RenewTime.Time))
+			}
+			lv1Before = lv1
 		}
 	}
 
@@ -145,10 +175,10 @@ func testNodeRun(t *testing.T, enableLease bool) {
 	nw.Stop()
 
 	assert.Check(t, atLeast(nodeUpdates, expectAtLeast))
-	if enableLease {
-		assert.Check(t, atLeast(leaseUpdates, expectAtLeast))
-	} else {
+	if enableLease == leasenone {
 		assert.Check(t, cmp.Equal(leaseUpdates, 0))
+	} else {
+		assert.Check(t, atLeast(leaseUpdates, expectAtLeast))
 	}
 
 	// trigger an async node status update


### PR DESCRIPTION
This sits on top of the work in https://github.com/virtual-kubelet/virtual-kubelet/pull/931 to finish the work to add a V1 lease controller. For the most part, this code is borrowed from K8s. The code has moved here:
https://github.com/kubernetes/component-helpers/tree/master/apimachinery/lease