### PR TITLE
log: fix klog depth and output format

### DIFF
--- a/log/klogv2/klogv2_test.go
+++ b/log/klogv2/klogv2_test.go
@@ -1,0 +1,60 @@
+// Copyright © 2021 The virtual-kubelet authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package klogv2
+
+import (
+	"testing"
+
+	"github.com/virtual-kubelet/virtual-kubelet/log"
+)
+
+func TestFieldMap_String(t *testing.T) {
+	var tests = []struct {
+		fields   fieldMap
+		expected string
+	}{
+		{
+			fieldMap{Fields: nil},
+			"",
+		},
+		{
+			fieldMap{Fields: make(log.Fields)},
+			"",
+		},
+		{
+			fieldMap{Fields: map[string]interface{}{"one": 1}},
+			" [one=1]",
+		},
+		{
+			fieldMap{Fields: map[string]interface{}{"one": 1, "two": 2}},
+			" [one=1 two=2]",
+		},
+	}
+
+	for _, tt := range tests {
+		// Assert fields haven't been processed yet.
+		if len(tt.fields.processedFields) > 0 {
+			t.Fatal("fields shouldn't have been processed yet")
+		}
+		// Assert fields have been processed, if any.
+		actual := tt.fields.String()
+		if len(tt.fields.Fields) > 0 && len(tt.fields.processedFields) == 0 {
+			t.Fatal("fields should have been processed by now")
+		}
+		// Assert processFields yields desired results.
+		if actual != tt.expected {
+			t.Fatalf("expected: %s, got: %s", actual, tt.expected)
+		}
+	}
+}

--- a/log/klogv2/klogv2_test.go
+++ b/log/klogv2/klogv2_test.go
@@ -21,40 +21,47 @@ import (
 
 func TestFieldMap_String(t *testing.T) {
 	var tests = []struct {
-		fields   fieldMap
+		desc     string
+		fields   *fieldMap
 		expected string
 	}{
 		{
-			fieldMap{Fields: nil},
-			"",
+			desc:     "fieldMap with nil fields",
+			fields:   &fieldMap{Fields: nil},
+			expected: "",
 		},
 		{
-			fieldMap{Fields: make(log.Fields)},
-			"",
+			desc:     "fieldMap with empty fields",
+			fields:   &fieldMap{Fields: make(log.Fields)},
+			expected: "",
 		},
 		{
-			fieldMap{Fields: map[string]interface{}{"one": 1}},
-			" [one=1]",
+			desc:     "fieldMap with single field",
+			fields:   &fieldMap{Fields: map[string]interface{}{"one": 1}},
+			expected: " [one=1]",
 		},
 		{
-			fieldMap{Fields: map[string]interface{}{"one": 1, "two": 2}},
-			" [one=1 two=2]",
+			desc:     "fieldMap with two fields",
+			fields:   &fieldMap{Fields: map[string]interface{}{"one": 1, "two": 2}},
+			expected: " [one=1 two=2]",
 		},
 	}
 
 	for _, tt := range tests {
-		// Assert fields haven't been processed yet.
-		if len(tt.fields.processedFields) > 0 {
-			t.Fatal("fields shouldn't have been processed yet")
-		}
-		// Assert fields have been processed, if any.
-		actual := tt.fields.String()
-		if len(tt.fields.Fields) > 0 && len(tt.fields.processedFields) == 0 {
-			t.Fatal("fields should have been processed by now")
-		}
-		// Assert processFields yields desired results.
-		if actual != tt.expected {
-			t.Fatalf("expected: %s, got: %s", actual, tt.expected)
-		}
+		t.Run(tt.desc, func(t *testing.T) {
+			// Assert fields haven't been processed yet.
+			if len(tt.fields.processedFields) > 0 {
+				t.Fatal("fields shouldn't have been processed yet")
+			}
+			// Assert fields have been processed, if any.
+			actual := tt.fields.String()
+			if len(tt.fields.Fields) > 0 && len(tt.fields.processedFields) == 0 {
+				t.Fatal("fields should have been processed by now")
+			}
+			// Assert processFields yields desired results.
+			if actual != tt.expected {
+				t.Fatalf("expected: %s, got: %s", actual, tt.expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Previously:
```
# ./systemk --kubeconfig systemk.kubeconfig --nodename systemk
I0112 13:06:38.331656    2784 klogv2.go:55] Installing [policyrcd-script-zg2], to prevent installed daemons from starting%!(EXTRA map[string]interface {}=map[])
I0112 13:06:38.331697    2784 klogv2.go:55] Checking if ["policyrcd-script-zg2"] is installed%!(EXTRA map[string]interface {}=map[])
I0112 13:06:38.558750    2784 klogv2.go:55] Using internal/external IP addresses: [192.168.64.15 192.168.64.15]/map[]
I0112 13:06:38.559154    2784 klogv2.go:51] [No certificates found, disabling GetContainerLogs] map[]
E0112 13:06:38.566320    2784 klogv2.go:67] [TLS certificates not provided, not setting up pod http server] map[caPath:]
I0112 13:06:38.566624    2784 klogv2.go:51] [Initialized] map[node:systemk operatingSystem:Linux provider:systemd watchedNamespace:]
I0112 13:06:38.569267    2784 klogv2.go:51] [Pod cache in-sync] map[node:systemk operatingSystem:Linux provider:systemd watchedNamespace:]
I0112 13:06:38.569599    2784 klogv2.go:51] [GetPods called] map[]
I0112 13:06:38.573789    2784 klogv2.go:55] [346] statuses returned%!(EXTRA map[string]interface {}=map[])
I0112 13:06:38.574123    2784 klogv2.go:55] Left with [0 %!d(string=systemk)] statuses for prefix map[]
I0112 13:06:38.574377    2784 klogv2.go:51] [starting workers] map[node:systemk operatingSystem:Linux provider:systemd watchedNamespace:]
I0112 13:06:38.575610    2784 klogv2.go:51] [started workers] map[node:systemk operatingSystem:Linux provider:systemd watchedNamespace:]
```

With this fix:
```
# ./systemk --kubeconfig systemk.kubeconfig --nodename systemk
I0114 19:59:00.128698    4878 provider.go:64] Installing policyrcd-script-zg2, to prevent installed daemons from starting [provider=systemk]
I0114 19:59:00.128733    4878 debian.go:31] Checking if "policyrcd-script-zg2" is installed [provider=systemk]
I0114 19:59:00.359249    4878 main.go:103] Using internal/external IP addresses: 192.168.64.15/192.168.64.15 [provider=systemk]
I0114 19:59:00.359561    4878 main.go:107] No certificates found, disabling GetContainerLogs [provider=systemk]
E0114 19:59:00.367313    4878 http.go:107] TLS certificates not provided, not setting up pod http server [caPath=]
I0114 19:59:00.367650    4878 root.go:250] Initialized [node=systemk operatingSystem=Linux provider=systemd watchedNamespace=]
I0114 19:59:00.370525    4878 podcontroller.go:287] Pod cache in-sync [node=systemk operatingSystem=Linux provider=systemd watchedNamespace=]
I0114 19:59:00.370825    4878 pod.go:36] GetPods called [provider=systemk]
I0114 19:59:00.375609    4878 manager.go:205] 346 statuses returned [provider=systemk]
I0114 19:59:00.380808    4878 manager.go:223] Left with 0 statuses for prefix "systemk" [provider=systemk]
I0114 19:59:00.381093    4878 podcontroller.go:368] starting workers [node=systemk operatingSystem=Linux provider=systemd watchedNamespace=]
I0114 19:59:00.381361    4878 podcontroller.go:380] started workers [node=systemk operatingSystem=Linux provider=systemd watchedNamespace=]
```

cc @miekg (yep, working on better klog support ;))