### PR TITLE
Remove k8s.io/kubernetes dep from env.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6
+	k8s.io/apiserver v0.18.4
 	k8s.io/client-go v0.18.6
 	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.0.0

--- a/internal/kubernetes/fieldpath/doc.go
+++ b/internal/kubernetes/fieldpath/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fieldpath supplies methods for extracting fields from objects
+// given a path to a field.
+package fieldpath // import "k8s.io/kubernetes/pkg/fieldpath"

--- a/internal/kubernetes/fieldpath/fieldpath.go
+++ b/internal/kubernetes/fieldpath/fieldpath.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fieldpath
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// FormatMap formats map[string]string to a string.
+func FormatMap(m map[string]string) (fmtStr string) {
+	// output with keys in sorted order to provide stable output
+	keys := sets.NewString()
+	for key := range m {
+		keys.Insert(key)
+	}
+	for _, key := range keys.List() {
+		fmtStr += fmt.Sprintf("%v=%q\n", key, m[key])
+	}
+	fmtStr = strings.TrimSuffix(fmtStr, "\n")
+
+	return
+}
+
+// ExtractFieldPathAsString extracts the field from the given object
+// and returns it as a string.  The object must be a pointer to an
+// API type.
+func ExtractFieldPathAsString(obj interface{}, fieldPath string) (string, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return "", err
+	}
+
+	if path, subscript, ok := SplitMaybeSubscriptedPath(fieldPath); ok {
+		switch path {
+		case "metadata.annotations":
+			if errs := validation.IsQualifiedName(strings.ToLower(subscript)); len(errs) != 0 {
+				return "", fmt.Errorf("invalid key subscript in %s: %s", fieldPath, strings.Join(errs, ";"))
+			}
+			return accessor.GetAnnotations()[subscript], nil
+		case "metadata.labels":
+			if errs := validation.IsQualifiedName(subscript); len(errs) != 0 {
+				return "", fmt.Errorf("invalid key subscript in %s: %s", fieldPath, strings.Join(errs, ";"))
+			}
+			return accessor.GetLabels()[subscript], nil
+		default:
+			return "", fmt.Errorf("fieldPath %q does not support subscript", fieldPath)
+		}
+	}
+
+	switch fieldPath {
+	case "metadata.annotations":
+		return FormatMap(accessor.GetAnnotations()), nil
+	case "metadata.labels":
+		return FormatMap(accessor.GetLabels()), nil
+	case "metadata.name":
+		return accessor.GetName(), nil
+	case "metadata.namespace":
+		return accessor.GetNamespace(), nil
+	case "metadata.uid":
+		return string(accessor.GetUID()), nil
+	}
+
+	return "", fmt.Errorf("unsupported fieldPath: %v", fieldPath)
+}
+
+// SplitMaybeSubscriptedPath checks whether the specified fieldPath is
+// subscripted, and
+//  - if yes, this function splits the fieldPath into path and subscript, and
+//    returns (path, subscript, true).
+//  - if no, this function returns (fieldPath, "", false).
+//
+// Example inputs and outputs:
+//  - "metadata.annotations['myKey']" --> ("metadata.annotations", "myKey", true)
+//  - "metadata.annotations['a[b]c']" --> ("metadata.annotations", "a[b]c", true)
+//  - "metadata.labels['']"           --> ("metadata.labels", "", true)
+//  - "metadata.labels"               --> ("metadata.labels", "", false)
+func SplitMaybeSubscriptedPath(fieldPath string) (string, string, bool) {
+	if !strings.HasSuffix(fieldPath, "']") {
+		return fieldPath, "", false
+	}
+	s := strings.TrimSuffix(fieldPath, "']")
+	parts := strings.SplitN(s, "['", 2)
+	if len(parts) < 2 {
+		return fieldPath, "", false
+	}
+	if len(parts[0]) == 0 {
+		return fieldPath, "", false
+	}
+	return parts[0], parts[1], true
+}

--- a/internal/kubernetes/fieldpath/fieldpath_test.go
+++ b/internal/kubernetes/fieldpath/fieldpath_test.go
@@ -1,0 +1,270 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fieldpath
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExtractFieldPathAsString(t *testing.T) {
+	cases := []struct {
+		name                    string
+		fieldPath               string
+		obj                     interface{}
+		expectedValue           string
+		expectedMessageFragment string
+	}{
+		{
+			name:                    "not an API object",
+			fieldPath:               "metadata.name",
+			obj:                     "",
+			expectedMessageFragment: "object does not implement the Object interfaces",
+		},
+		{
+			name:      "ok - namespace",
+			fieldPath: "metadata.namespace",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "object-namespace",
+				},
+			},
+			expectedValue: "object-namespace",
+		},
+		{
+			name:      "ok - name",
+			fieldPath: "metadata.name",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "object-name",
+				},
+			},
+			expectedValue: "object-name",
+		},
+		{
+			name:      "ok - labels",
+			fieldPath: "metadata.labels",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"key": "value"},
+				},
+			},
+			expectedValue: "key=\"value\"",
+		},
+		{
+			name:      "ok - labels bslash n",
+			fieldPath: "metadata.labels",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"key": "value\n"},
+				},
+			},
+			expectedValue: "key=\"value\\n\"",
+		},
+		{
+			name:      "ok - annotations",
+			fieldPath: "metadata.annotations",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"builder": "john-doe"},
+				},
+			},
+			expectedValue: "builder=\"john-doe\"",
+		},
+		{
+			name:      "ok - annotation",
+			fieldPath: "metadata.annotations['spec.pod.beta.kubernetes.io/statefulset-index']",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"spec.pod.beta.kubernetes.io/statefulset-index": "1"},
+				},
+			},
+			expectedValue: "1",
+		},
+		{
+			name:      "ok - annotation",
+			fieldPath: "metadata.annotations['Www.k8s.io/test']",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"Www.k8s.io/test": "1"},
+				},
+			},
+			expectedValue: "1",
+		},
+		{
+			name:      "ok - uid",
+			fieldPath: "metadata.uid",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: "b70b3269-858e-12a8-9cf2-1232a194038a",
+				},
+			},
+			expectedValue: "b70b3269-858e-12a8-9cf2-1232a194038a",
+		},
+		{
+			name:      "ok - label",
+			fieldPath: "metadata.labels['something']",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"something": "label value",
+					},
+				},
+			},
+			expectedValue: "label value",
+		},
+		{
+			name:      "invalid expression",
+			fieldPath: "metadata.whoops",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "object-namespace",
+				},
+			},
+			expectedMessageFragment: "unsupported fieldPath",
+		},
+		{
+			name:      "invalid annotation key",
+			fieldPath: "metadata.annotations['invalid~key']",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"foo": "bar"},
+				},
+			},
+			expectedMessageFragment: "invalid key subscript in metadata.annotations",
+		},
+		{
+			name:      "invalid label key",
+			fieldPath: "metadata.labels['Www.k8s.io/test']",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"foo": "bar"},
+				},
+			},
+			expectedMessageFragment: "invalid key subscript in metadata.labels",
+		},
+		{
+			name:                    "invalid subscript",
+			fieldPath:               "metadata.notexisting['something']",
+			obj:                     &v1.Pod{},
+			expectedMessageFragment: "fieldPath \"metadata.notexisting['something']\" does not support subscript",
+		},
+	}
+
+	for _, tc := range cases {
+		actual, err := ExtractFieldPathAsString(tc.obj, tc.fieldPath)
+		if err != nil {
+			if tc.expectedMessageFragment != "" {
+				if !strings.Contains(err.Error(), tc.expectedMessageFragment) {
+					t.Errorf("%v: unexpected error message: %q, expected to contain %q", tc.name, err, tc.expectedMessageFragment)
+				}
+			} else {
+				t.Errorf("%v: unexpected error: %v", tc.name, err)
+			}
+		} else if tc.expectedMessageFragment != "" {
+			t.Errorf("%v: expected error: %v", tc.name, tc.expectedMessageFragment)
+		} else if e := tc.expectedValue; e != "" && e != actual {
+			t.Errorf("%v: unexpected result; got %q, expected %q", tc.name, actual, e)
+		}
+	}
+}
+
+func TestSplitMaybeSubscriptedPath(t *testing.T) {
+	cases := []struct {
+		fieldPath         string
+		expectedPath      string
+		expectedSubscript string
+		expectedOK        bool
+	}{
+		{
+			fieldPath:         "metadata.annotations['key']",
+			expectedPath:      "metadata.annotations",
+			expectedSubscript: "key",
+			expectedOK:        true,
+		},
+		{
+			fieldPath:         "metadata.annotations['a[b']c']",
+			expectedPath:      "metadata.annotations",
+			expectedSubscript: "a[b']c",
+			expectedOK:        true,
+		},
+		{
+			fieldPath:         "metadata.labels['['key']",
+			expectedPath:      "metadata.labels",
+			expectedSubscript: "['key",
+			expectedOK:        true,
+		},
+		{
+			fieldPath:         "metadata.labels['key']']",
+			expectedPath:      "metadata.labels",
+			expectedSubscript: "key']",
+			expectedOK:        true,
+		},
+		{
+			fieldPath:         "metadata.labels['']",
+			expectedPath:      "metadata.labels",
+			expectedSubscript: "",
+			expectedOK:        true,
+		},
+		{
+			fieldPath:         "metadata.labels[' ']",
+			expectedPath:      "metadata.labels",
+			expectedSubscript: " ",
+			expectedOK:        true,
+		},
+		{
+			fieldPath:  "metadata.labels[ 'key' ]",
+			expectedOK: false,
+		},
+		{
+			fieldPath:  "metadata.labels[]",
+			expectedOK: false,
+		},
+		{
+			fieldPath:  "metadata.labels[']",
+			expectedOK: false,
+		},
+		{
+			fieldPath:  "metadata.labels['key']foo",
+			expectedOK: false,
+		},
+		{
+			fieldPath:  "['key']",
+			expectedOK: false,
+		},
+		{
+			fieldPath:  "metadata.labels",
+			expectedOK: false,
+		},
+	}
+	for _, tc := range cases {
+		path, subscript, ok := SplitMaybeSubscriptedPath(tc.fieldPath)
+		if !ok {
+			if tc.expectedOK {
+				t.Errorf("SplitMaybeSubscriptedPath(%q) expected to return (_, _, true)", tc.fieldPath)
+			}
+			continue
+		}
+		if path != tc.expectedPath || subscript != tc.expectedSubscript {
+			t.Errorf("SplitMaybeSubscriptedPath(%q) = (%q, %q, true), expect (%q, %q, true)",
+				tc.fieldPath, path, subscript, tc.expectedPath, tc.expectedSubscript)
+		}
+	}
+}

--- a/internal/kubernetes/pods/helpers.go
+++ b/internal/kubernetes/pods/helpers.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/fieldpath"
+)
+
+// ContainerVisitorWithPath is called with each container and the field.Path to that container,
+// and returns true if visiting should continue.
+type ContainerVisitorWithPath func(container *api.Container, path *field.Path) bool
+
+// VisitContainersWithPath invokes the visitor function with a pointer to the spec
+// of every container in the given pod spec and the field.Path to that container.
+// If visitor returns false, visiting is short-circuited. VisitContainersWithPath returns true if visiting completes,
+// false if visiting was short-circuited.
+func VisitContainersWithPath(podSpec *api.PodSpec, specPath *field.Path, visitor ContainerVisitorWithPath) bool {
+	fldPath := specPath.Child("initContainers")
+	for i := range podSpec.InitContainers {
+		if !visitor(&podSpec.InitContainers[i], fldPath.Index(i)) {
+			return false
+		}
+	}
+	fldPath = specPath.Child("containers")
+	for i := range podSpec.Containers {
+		if !visitor(&podSpec.Containers[i], fldPath.Index(i)) {
+			return false
+		}
+	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.EphemeralContainers) {
+		fldPath = specPath.Child("ephemeralContainers")
+		for i := range podSpec.EphemeralContainers {
+			if !visitor((*api.Container)(&podSpec.EphemeralContainers[i].EphemeralContainerCommon), fldPath.Index(i)) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// ConvertDownwardAPIFieldLabel converts the specified downward API field label
+// and its value in the pod of the specified version to the internal version,
+// and returns the converted label and value. This function returns an error if
+// the conversion fails.
+func ConvertDownwardAPIFieldLabel(version, label, value string) (string, string, error) {
+	if version != "v1" {
+		return "", "", fmt.Errorf("unsupported pod version: %s", version)
+	}
+
+	if path, _, ok := fieldpath.SplitMaybeSubscriptedPath(label); ok {
+		switch path {
+		case "metadata.annotations", "metadata.labels":
+			return label, value, nil
+		default:
+			return "", "", fmt.Errorf("field label does not support subscript: %s", label)
+		}
+	}
+
+	switch label {
+	case "metadata.annotations",
+		"metadata.labels",
+		"metadata.name",
+		"metadata.namespace",
+		"metadata.uid",
+		"spec.nodeName",
+		"spec.restartPolicy",
+		"spec.serviceAccountName",
+		"spec.schedulerName",
+		"status.phase",
+		"status.hostIP",
+		"status.podIP",
+		"status.podIPs":
+		return label, value, nil
+	// This is for backwards compatibility with old v1 clients which send spec.host
+	case "spec.host":
+		return "spec.nodeName", value, nil
+	default:
+		return "", "", fmt.Errorf("field label not supported: %s", label)
+	}
+}

--- a/internal/kubernetes/pods/helpers_test.go
+++ b/internal/kubernetes/pods/helpers_test.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+func TestVisitContainersWithPath(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EphemeralContainers, true)()
+
+	testCases := []struct {
+		description string
+		path        *field.Path
+		haveSpec    *api.PodSpec
+		wantNames   []string
+	}{
+		{
+			"empty podspec",
+			field.NewPath("spec"),
+			&api.PodSpec{},
+			[]string{},
+		},
+		{
+			"regular containers",
+			field.NewPath("spec"),
+			&api.PodSpec{
+				Containers: []api.Container{
+					{Name: "c1"},
+					{Name: "c2"},
+				},
+			},
+			[]string{"spec.containers[0]", "spec.containers[1]"},
+		},
+		{
+			"init containers",
+			field.NewPath("spec"),
+			&api.PodSpec{
+				InitContainers: []api.Container{
+					{Name: "i1"},
+					{Name: "i2"},
+				},
+			},
+			[]string{"spec.initContainers[0]", "spec.initContainers[1]"},
+		},
+		{
+			"regular and init containers",
+			field.NewPath("spec"),
+			&api.PodSpec{
+				Containers: []api.Container{
+					{Name: "c1"},
+					{Name: "c2"},
+				},
+				InitContainers: []api.Container{
+					{Name: "i1"},
+					{Name: "i2"},
+				},
+			},
+			[]string{"spec.initContainers[0]", "spec.initContainers[1]", "spec.containers[0]", "spec.containers[1]"},
+		},
+		{
+			"ephemeral containers",
+			field.NewPath("spec"),
+			&api.PodSpec{
+				Containers: []api.Container{
+					{Name: "c1"},
+					{Name: "c2"},
+				},
+				EphemeralContainers: []api.EphemeralContainer{
+					{EphemeralContainerCommon: api.EphemeralContainerCommon{Name: "e1"}},
+				},
+			},
+			[]string{"spec.containers[0]", "spec.containers[1]", "spec.ephemeralContainers[0]"},
+		},
+		{
+			"all container types",
+			field.NewPath("spec"),
+			&api.PodSpec{
+				Containers: []api.Container{
+					{Name: "c1"},
+					{Name: "c2"},
+				},
+				InitContainers: []api.Container{
+					{Name: "i1"},
+					{Name: "i2"},
+				},
+				EphemeralContainers: []api.EphemeralContainer{
+					{EphemeralContainerCommon: api.EphemeralContainerCommon{Name: "e1"}},
+					{EphemeralContainerCommon: api.EphemeralContainerCommon{Name: "e2"}},
+				},
+			},
+			[]string{"spec.initContainers[0]", "spec.initContainers[1]", "spec.containers[0]", "spec.containers[1]", "spec.ephemeralContainers[0]", "spec.ephemeralContainers[1]"},
+		},
+		{
+			"all container types with template pod path",
+			field.NewPath("template", "spec"),
+			&api.PodSpec{
+				Containers: []api.Container{
+					{Name: "c1"},
+					{Name: "c2"},
+				},
+				InitContainers: []api.Container{
+					{Name: "i1"},
+					{Name: "i2"},
+				},
+				EphemeralContainers: []api.EphemeralContainer{
+					{EphemeralContainerCommon: api.EphemeralContainerCommon{Name: "e1"}},
+					{EphemeralContainerCommon: api.EphemeralContainerCommon{Name: "e2"}},
+				},
+			},
+			[]string{"template.spec.initContainers[0]", "template.spec.initContainers[1]", "template.spec.containers[0]", "template.spec.containers[1]", "template.spec.ephemeralContainers[0]", "template.spec.ephemeralContainers[1]"},
+		},
+	}
+
+	for _, tc := range testCases {
+		gotNames := []string{}
+		VisitContainersWithPath(tc.haveSpec, tc.path, func(c *api.Container, p *field.Path) bool {
+			gotNames = append(gotNames, p.String())
+			return true
+		})
+		if !reflect.DeepEqual(gotNames, tc.wantNames) {
+			t.Errorf("VisitContainersWithPath() for test case %q visited containers %q, wanted to visit %q", tc.description, gotNames, tc.wantNames)
+		}
+	}
+}
+
+func TestConvertDownwardAPIFieldLabel(t *testing.T) {
+	testCases := []struct {
+		version       string
+		label         string
+		value         string
+		expectedErr   bool
+		expectedLabel string
+		expectedValue string
+	}{
+		{
+			version:     "v2",
+			label:       "metadata.name",
+			value:       "test-pod",
+			expectedErr: true,
+		},
+		{
+			version:     "v1",
+			label:       "invalid-label",
+			value:       "value",
+			expectedErr: true,
+		},
+		{
+			version:       "v1",
+			label:         "metadata.name",
+			value:         "test-pod",
+			expectedLabel: "metadata.name",
+			expectedValue: "test-pod",
+		},
+		{
+			version:       "v1",
+			label:         "metadata.annotations",
+			value:         "myValue",
+			expectedLabel: "metadata.annotations",
+			expectedValue: "myValue",
+		},
+		{
+			version:       "v1",
+			label:         "metadata.annotations['myKey']",
+			value:         "myValue",
+			expectedLabel: "metadata.annotations['myKey']",
+			expectedValue: "myValue",
+		},
+		{
+			version:       "v1",
+			label:         "spec.host",
+			value:         "127.0.0.1",
+			expectedLabel: "spec.nodeName",
+			expectedValue: "127.0.0.1",
+		},
+		{
+			version:       "v1",
+			label:         "status.podIPs",
+			value:         "10.244.0.6,fd00::6",
+			expectedLabel: "status.podIPs",
+			expectedValue: "10.244.0.6,fd00::6",
+		},
+		{
+			version:       "v1",
+			label:         "status.podIPs",
+			value:         "10.244.0.6",
+			expectedLabel: "status.podIPs",
+			expectedValue: "10.244.0.6",
+		},
+	}
+	for _, tc := range testCases {
+		label, value, err := ConvertDownwardAPIFieldLabel(tc.version, tc.label, tc.value)
+		if err != nil {
+			if tc.expectedErr {
+				continue
+			}
+			t.Errorf("ConvertDownwardAPIFieldLabel(%s, %s, %s) failed: %s",
+				tc.version, tc.label, tc.value, err)
+		}
+		if tc.expectedLabel != label || tc.expectedValue != value {
+			t.Errorf("ConvertDownwardAPIFieldLabel(%s, %s, %s) = (%s, %s, nil), expected (%s, %s, nil)",
+				tc.version, tc.label, tc.value, label, value, tc.expectedLabel, tc.expectedValue)
+		}
+	}
+}

--- a/internal/kubernetes/v1/helper/helpers.go
+++ b/internal/kubernetes/v1/helper/helpers.go
@@ -1,0 +1,453 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/kubernetes/pkg/apis/core/helper"
+)
+
+// IsExtendedResourceName returns true if:
+// 1. the resource name is not in the default namespace;
+// 2. resource name does not have "requests." prefix,
+// to avoid confusion with the convention in quota
+// 3. it satisfies the rules in IsQualifiedName() after converted into quota resource name
+func IsExtendedResourceName(name v1.ResourceName) bool {
+	if IsNativeResource(name) || strings.HasPrefix(string(name), v1.DefaultResourceRequestsPrefix) {
+		return false
+	}
+	// Ensure it satisfies the rules in IsQualifiedName() after converted into quota resource name
+	nameForQuota := fmt.Sprintf("%s%s", v1.DefaultResourceRequestsPrefix, string(name))
+	if errs := validation.IsQualifiedName(string(nameForQuota)); len(errs) != 0 {
+		return false
+	}
+	return true
+}
+
+// IsPrefixedNativeResource returns true if the resource name is in the
+// *kubernetes.io/ namespace.
+func IsPrefixedNativeResource(name v1.ResourceName) bool {
+	return strings.Contains(string(name), v1.ResourceDefaultNamespacePrefix)
+}
+
+// IsNativeResource returns true if the resource name is in the
+// *kubernetes.io/ namespace. Partially-qualified (unprefixed) names are
+// implicitly in the kubernetes.io/ namespace.
+func IsNativeResource(name v1.ResourceName) bool {
+	return !strings.Contains(string(name), "/") ||
+		IsPrefixedNativeResource(name)
+}
+
+// IsHugePageResourceName returns true if the resource name has the huge page
+// resource prefix.
+func IsHugePageResourceName(name v1.ResourceName) bool {
+	return strings.HasPrefix(string(name), v1.ResourceHugePagesPrefix)
+}
+
+// HugePageResourceName returns a ResourceName with the canonical hugepage
+// prefix prepended for the specified page size.  The page size is converted
+// to its canonical representation.
+func HugePageResourceName(pageSize resource.Quantity) v1.ResourceName {
+	return v1.ResourceName(fmt.Sprintf("%s%s", v1.ResourceHugePagesPrefix, pageSize.String()))
+}
+
+// HugePageSizeFromResourceName returns the page size for the specified huge page
+// resource name.  If the specified input is not a valid huge page resource name
+// an error is returned.
+func HugePageSizeFromResourceName(name v1.ResourceName) (resource.Quantity, error) {
+	if !IsHugePageResourceName(name) {
+		return resource.Quantity{}, fmt.Errorf("resource name: %s is an invalid hugepage name", name)
+	}
+	pageSize := strings.TrimPrefix(string(name), v1.ResourceHugePagesPrefix)
+	return resource.ParseQuantity(pageSize)
+}
+
+// HugePageUnitSizeFromByteSize returns hugepage size has the format.
+// `size` must be guaranteed to divisible into the largest units that can be expressed.
+// <size><unit-prefix>B (1024 = "1KB", 1048576 = "1MB", etc).
+func HugePageUnitSizeFromByteSize(size int64) (string, error) {
+	// hugePageSizeUnitList is borrowed from opencontainers/runc/libcontainer/cgroups/utils.go
+	var hugePageSizeUnitList = []string{"B", "KB", "MB", "GB", "TB", "PB"}
+	idx := 0
+	len := len(hugePageSizeUnitList) - 1
+	for size%1024 == 0 && idx < len {
+		size /= 1024
+		idx++
+	}
+	if size > 1024 && idx < len {
+		return "", fmt.Errorf("size: %d%s must be guaranteed to divisible into the largest units", size, hugePageSizeUnitList[idx])
+	}
+	return fmt.Sprintf("%d%s", size, hugePageSizeUnitList[idx]), nil
+}
+
+// IsHugePageMedium returns true if the volume medium is in 'HugePages[-size]' format
+func IsHugePageMedium(medium v1.StorageMedium) bool {
+	if medium == v1.StorageMediumHugePages {
+		return true
+	}
+	return strings.HasPrefix(string(medium), string(v1.StorageMediumHugePagesPrefix))
+}
+
+// HugePageSizeFromMedium returns the page size for the specified huge page medium.
+// If the specified input is not a valid huge page medium an error is returned.
+func HugePageSizeFromMedium(medium v1.StorageMedium) (resource.Quantity, error) {
+	if !IsHugePageMedium(medium) {
+		return resource.Quantity{}, fmt.Errorf("medium: %s is not a hugepage medium", medium)
+	}
+	if medium == v1.StorageMediumHugePages {
+		return resource.Quantity{}, fmt.Errorf("medium: %s doesn't have size information", medium)
+	}
+	pageSize := strings.TrimPrefix(string(medium), string(v1.StorageMediumHugePagesPrefix))
+	return resource.ParseQuantity(pageSize)
+}
+
+// IsOvercommitAllowed returns true if the resource is in the default
+// namespace and is not hugepages.
+func IsOvercommitAllowed(name v1.ResourceName) bool {
+	return IsNativeResource(name) &&
+		!IsHugePageResourceName(name)
+}
+
+// IsAttachableVolumeResourceName returns true when the resource name is prefixed in attachable volume
+func IsAttachableVolumeResourceName(name v1.ResourceName) bool {
+	return strings.HasPrefix(string(name), v1.ResourceAttachableVolumesPrefix)
+}
+
+// IsServiceIPSet aims to check if the service's ClusterIP is set or not
+// the objective is not to perform validation here
+func IsServiceIPSet(service *v1.Service) bool {
+	return service.Spec.ClusterIP != v1.ClusterIPNone && service.Spec.ClusterIP != ""
+}
+
+// LoadBalancerStatusEqual evaluates the given load balancers' ingress IP addresses
+// and hostnames and returns true if equal or false if otherwise
+// TODO: make method on LoadBalancerStatus?
+func LoadBalancerStatusEqual(l, r *v1.LoadBalancerStatus) bool {
+	return ingressSliceEqual(l.Ingress, r.Ingress)
+}
+
+func ingressSliceEqual(lhs, rhs []v1.LoadBalancerIngress) bool {
+	if len(lhs) != len(rhs) {
+		return false
+	}
+	for i := range lhs {
+		if !ingressEqual(&lhs[i], &rhs[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func ingressEqual(lhs, rhs *v1.LoadBalancerIngress) bool {
+	if lhs.IP != rhs.IP {
+		return false
+	}
+	if lhs.Hostname != rhs.Hostname {
+		return false
+	}
+	return true
+}
+
+// GetAccessModesAsString returns a string representation of an array of access modes.
+// modes, when present, are always in the same order: RWO,ROX,RWX.
+func GetAccessModesAsString(modes []v1.PersistentVolumeAccessMode) string {
+	modes = removeDuplicateAccessModes(modes)
+	modesStr := []string{}
+	if containsAccessMode(modes, v1.ReadWriteOnce) {
+		modesStr = append(modesStr, "RWO")
+	}
+	if containsAccessMode(modes, v1.ReadOnlyMany) {
+		modesStr = append(modesStr, "ROX")
+	}
+	if containsAccessMode(modes, v1.ReadWriteMany) {
+		modesStr = append(modesStr, "RWX")
+	}
+	return strings.Join(modesStr, ",")
+}
+
+// GetAccessModesFromString returns an array of AccessModes from a string created by GetAccessModesAsString
+func GetAccessModesFromString(modes string) []v1.PersistentVolumeAccessMode {
+	strmodes := strings.Split(modes, ",")
+	accessModes := []v1.PersistentVolumeAccessMode{}
+	for _, s := range strmodes {
+		s = strings.Trim(s, " ")
+		switch {
+		case s == "RWO":
+			accessModes = append(accessModes, v1.ReadWriteOnce)
+		case s == "ROX":
+			accessModes = append(accessModes, v1.ReadOnlyMany)
+		case s == "RWX":
+			accessModes = append(accessModes, v1.ReadWriteMany)
+		}
+	}
+	return accessModes
+}
+
+// removeDuplicateAccessModes returns an array of access modes without any duplicates
+func removeDuplicateAccessModes(modes []v1.PersistentVolumeAccessMode) []v1.PersistentVolumeAccessMode {
+	accessModes := []v1.PersistentVolumeAccessMode{}
+	for _, m := range modes {
+		if !containsAccessMode(accessModes, m) {
+			accessModes = append(accessModes, m)
+		}
+	}
+	return accessModes
+}
+
+func containsAccessMode(modes []v1.PersistentVolumeAccessMode, mode v1.PersistentVolumeAccessMode) bool {
+	for _, m := range modes {
+		if m == mode {
+			return true
+		}
+	}
+	return false
+}
+
+// NodeSelectorRequirementKeysExistInNodeSelectorTerms checks if a NodeSelectorTerm with key is already specified in terms
+func NodeSelectorRequirementKeysExistInNodeSelectorTerms(reqs []v1.NodeSelectorRequirement, terms []v1.NodeSelectorTerm) bool {
+	for _, req := range reqs {
+		for _, term := range terms {
+			for _, r := range term.MatchExpressions {
+				if r.Key == req.Key {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// TopologySelectorRequirementsAsSelector converts the []TopologySelectorLabelRequirement api type into a struct
+// that implements labels.Selector.
+func TopologySelectorRequirementsAsSelector(tsm []v1.TopologySelectorLabelRequirement) (labels.Selector, error) {
+	if len(tsm) == 0 {
+		return labels.Nothing(), nil
+	}
+
+	selector := labels.NewSelector()
+	for _, expr := range tsm {
+		r, err := labels.NewRequirement(expr.Key, selection.In, expr.Values)
+		if err != nil {
+			return nil, err
+		}
+		selector = selector.Add(*r)
+	}
+
+	return selector, nil
+}
+
+// MatchTopologySelectorTerms checks whether given labels match topology selector terms in ORed;
+// nil or empty term matches no objects; while empty term list matches all objects.
+func MatchTopologySelectorTerms(topologySelectorTerms []v1.TopologySelectorTerm, lbls labels.Set) bool {
+	if len(topologySelectorTerms) == 0 {
+		// empty term list matches all objects
+		return true
+	}
+
+	for _, req := range topologySelectorTerms {
+		// nil or empty term selects no objects
+		if len(req.MatchLabelExpressions) == 0 {
+			continue
+		}
+
+		labelSelector, err := TopologySelectorRequirementsAsSelector(req.MatchLabelExpressions)
+		if err != nil || !labelSelector.Matches(lbls) {
+			continue
+		}
+
+		return true
+	}
+
+	return false
+}
+
+// AddOrUpdateTolerationInPodSpec tries to add a toleration to the toleration list in PodSpec.
+// Returns true if something was updated, false otherwise.
+func AddOrUpdateTolerationInPodSpec(spec *v1.PodSpec, toleration *v1.Toleration) bool {
+	podTolerations := spec.Tolerations
+
+	var newTolerations []v1.Toleration
+	updated := false
+	for i := range podTolerations {
+		if toleration.MatchToleration(&podTolerations[i]) {
+			if helper.Semantic.DeepEqual(toleration, podTolerations[i]) {
+				return false
+			}
+			newTolerations = append(newTolerations, *toleration)
+			updated = true
+			continue
+		}
+
+		newTolerations = append(newTolerations, podTolerations[i])
+	}
+
+	if !updated {
+		newTolerations = append(newTolerations, *toleration)
+	}
+
+	spec.Tolerations = newTolerations
+	return true
+}
+
+// AddOrUpdateTolerationInPod tries to add a toleration to the pod's toleration list.
+// Returns true if something was updated, false otherwise.
+func AddOrUpdateTolerationInPod(pod *v1.Pod, toleration *v1.Toleration) bool {
+	return AddOrUpdateTolerationInPodSpec(&pod.Spec, toleration)
+}
+
+// TolerationsTolerateTaint checks if taint is tolerated by any of the tolerations.
+func TolerationsTolerateTaint(tolerations []v1.Toleration, taint *v1.Taint) bool {
+	for i := range tolerations {
+		if tolerations[i].ToleratesTaint(taint) {
+			return true
+		}
+	}
+	return false
+}
+
+type taintsFilterFunc func(*v1.Taint) bool
+
+// TolerationsTolerateTaintsWithFilter checks if given tolerations tolerates
+// all the taints that apply to the filter in given taint list.
+// DEPRECATED: Please use FindMatchingUntoleratedTaint instead.
+func TolerationsTolerateTaintsWithFilter(tolerations []v1.Toleration, taints []v1.Taint, applyFilter taintsFilterFunc) bool {
+	_, isUntolerated := FindMatchingUntoleratedTaint(taints, tolerations, applyFilter)
+	return !isUntolerated
+}
+
+// FindMatchingUntoleratedTaint checks if the given tolerations tolerates
+// all the filtered taints, and returns the first taint without a toleration
+func FindMatchingUntoleratedTaint(taints []v1.Taint, tolerations []v1.Toleration, inclusionFilter taintsFilterFunc) (v1.Taint, bool) {
+	filteredTaints := getFilteredTaints(taints, inclusionFilter)
+	for _, taint := range filteredTaints {
+		if !TolerationsTolerateTaint(tolerations, &taint) {
+			return taint, true
+		}
+	}
+	return v1.Taint{}, false
+}
+
+// getFilteredTaints returns a list of taints satisfying the filter predicate
+func getFilteredTaints(taints []v1.Taint, inclusionFilter taintsFilterFunc) []v1.Taint {
+	if inclusionFilter == nil {
+		return taints
+	}
+	filteredTaints := []v1.Taint{}
+	for _, taint := range taints {
+		if !inclusionFilter(&taint) {
+			continue
+		}
+		filteredTaints = append(filteredTaints, taint)
+	}
+	return filteredTaints
+}
+
+// GetMatchingTolerations returns true and list of Tolerations matching all Taints if all are tolerated, or false otherwise.
+func GetMatchingTolerations(taints []v1.Taint, tolerations []v1.Toleration) (bool, []v1.Toleration) {
+	if len(taints) == 0 {
+		return true, []v1.Toleration{}
+	}
+	if len(tolerations) == 0 && len(taints) > 0 {
+		return false, []v1.Toleration{}
+	}
+	result := []v1.Toleration{}
+	for i := range taints {
+		tolerated := false
+		for j := range tolerations {
+			if tolerations[j].ToleratesTaint(&taints[i]) {
+				result = append(result, tolerations[j])
+				tolerated = true
+				break
+			}
+		}
+		if !tolerated {
+			return false, []v1.Toleration{}
+		}
+	}
+	return true, result
+}
+
+// GetAvoidPodsFromNodeAnnotations scans the list of annotations and
+// returns the pods that needs to be avoided for this node from scheduling
+func GetAvoidPodsFromNodeAnnotations(annotations map[string]string) (v1.AvoidPods, error) {
+	var avoidPods v1.AvoidPods
+	if len(annotations) > 0 && annotations[v1.PreferAvoidPodsAnnotationKey] != "" {
+		err := json.Unmarshal([]byte(annotations[v1.PreferAvoidPodsAnnotationKey]), &avoidPods)
+		if err != nil {
+			return avoidPods, err
+		}
+	}
+	return avoidPods, nil
+}
+
+// GetPersistentVolumeClass returns StorageClassName.
+func GetPersistentVolumeClass(volume *v1.PersistentVolume) string {
+	// Use beta annotation first
+	if class, found := volume.Annotations[v1.BetaStorageClassAnnotation]; found {
+		return class
+	}
+
+	return volume.Spec.StorageClassName
+}
+
+// GetPersistentVolumeClaimClass returns StorageClassName. If no storage class was
+// requested, it returns "".
+func GetPersistentVolumeClaimClass(claim *v1.PersistentVolumeClaim) string {
+	// Use beta annotation first
+	if class, found := claim.Annotations[v1.BetaStorageClassAnnotation]; found {
+		return class
+	}
+
+	if claim.Spec.StorageClassName != nil {
+		return *claim.Spec.StorageClassName
+	}
+
+	return ""
+}
+
+// ScopedResourceSelectorRequirementsAsSelector converts the ScopedResourceSelectorRequirement api type into a struct that implements
+// labels.Selector.
+func ScopedResourceSelectorRequirementsAsSelector(ssr v1.ScopedResourceSelectorRequirement) (labels.Selector, error) {
+	selector := labels.NewSelector()
+	var op selection.Operator
+	switch ssr.Operator {
+	case v1.ScopeSelectorOpIn:
+		op = selection.In
+	case v1.ScopeSelectorOpNotIn:
+		op = selection.NotIn
+	case v1.ScopeSelectorOpExists:
+		op = selection.Exists
+	case v1.ScopeSelectorOpDoesNotExist:
+		op = selection.DoesNotExist
+	default:
+		return nil, fmt.Errorf("%q is not a valid scope selector operator", ssr.Operator)
+	}
+	r, err := labels.NewRequirement(string(ssr.ScopeName), op, ssr.Values)
+	if err != nil {
+		return nil, err
+	}
+	selector = selector.Add(*r)
+	return selector, nil
+}

--- a/internal/kubernetes/v1/helper/helpers_test.go
+++ b/internal/kubernetes/v1/helper/helpers_test.go
@@ -1,0 +1,1002 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestIsNativeResource(t *testing.T) {
+	testCases := []struct {
+		resourceName v1.ResourceName
+		expectVal    bool
+	}{
+		{
+			resourceName: "pod.alpha.kubernetes.io/opaque-int-resource-foo",
+			expectVal:    true,
+		},
+		{
+			resourceName: "kubernetes.io/resource-foo",
+			expectVal:    true,
+		},
+		{
+			resourceName: "foo",
+			expectVal:    true,
+		},
+		{
+			resourceName: "a/b",
+			expectVal:    false,
+		},
+		{
+			resourceName: "",
+			expectVal:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("resourceName input=%s, expected value=%v", tc.resourceName, tc.expectVal), func(t *testing.T) {
+			t.Parallel()
+			v := IsNativeResource(tc.resourceName)
+			if v != tc.expectVal {
+				t.Errorf("Got %v but expected %v", v, tc.expectVal)
+			}
+		})
+	}
+}
+
+func TestHugePageSizeFromResourceName(t *testing.T) {
+	expected100m, _ := resource.ParseQuantity("100m")
+	testCases := []struct {
+		resourceName v1.ResourceName
+		expectVal    resource.Quantity
+		expectErr    bool
+	}{
+		{
+			resourceName: "pod.alpha.kubernetes.io/opaque-int-resource-foo",
+			expectVal:    resource.Quantity{},
+			expectErr:    true,
+		},
+		{
+			resourceName: "hugepages-",
+			expectVal:    resource.Quantity{},
+			expectErr:    true,
+		},
+		{
+			resourceName: "hugepages-100m",
+			expectVal:    expected100m,
+			expectErr:    false,
+		},
+		{
+			resourceName: "",
+			expectVal:    resource.Quantity{},
+			expectErr:    true,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("resourceName input=%s, expected value=%v", tc.resourceName, tc.expectVal), func(t *testing.T) {
+			t.Parallel()
+			v, err := HugePageSizeFromResourceName(tc.resourceName)
+			if err == nil && tc.expectErr {
+				t.Errorf("[%v]expected error but got none.", i)
+			}
+			if err != nil && !tc.expectErr {
+				t.Errorf("[%v]did not expect error but got: %v", i, err)
+			}
+			if v != tc.expectVal {
+				t.Errorf("Got %v but expected %v", v, tc.expectVal)
+			}
+		})
+	}
+}
+
+func TestHugePageSizeFromMedium(t *testing.T) {
+	testCases := []struct {
+		description string
+		medium      v1.StorageMedium
+		expectVal   resource.Quantity
+		expectErr   bool
+	}{
+		{
+			description: "Invalid hugepages medium",
+			medium:      "Memory",
+			expectVal:   resource.Quantity{},
+			expectErr:   true,
+		},
+		{
+			description: "Invalid hugepages medium",
+			medium:      "Memory",
+			expectVal:   resource.Quantity{},
+			expectErr:   true,
+		},
+		{
+			description: "Invalid: HugePages without size",
+			medium:      "HugePages",
+			expectVal:   resource.Quantity{},
+			expectErr:   true,
+		},
+		{
+			description: "Invalid: HugePages without size",
+			medium:      "HugePages",
+			expectVal:   resource.Quantity{},
+			expectErr:   true,
+		},
+		{
+			description: "Valid: HugePages-1Gi",
+			medium:      "HugePages-1Gi",
+			expectVal:   resource.MustParse("1Gi"),
+			expectErr:   false,
+		},
+		{
+			description: "Valid: HugePages-2Mi",
+			medium:      "HugePages-2Mi",
+			expectVal:   resource.MustParse("2Mi"),
+			expectErr:   false,
+		},
+		{
+			description: "Valid: HugePages-64Ki",
+			medium:      "HugePages-64Ki",
+			expectVal:   resource.MustParse("64Ki"),
+			expectErr:   false,
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+			v, err := HugePageSizeFromMedium(tc.medium)
+			if err == nil && tc.expectErr {
+				t.Errorf("[%v]expected error but got none.", i)
+			}
+			if err != nil && !tc.expectErr {
+				t.Errorf("[%v]did not expect error but got: %v", i, err)
+			}
+			if v != tc.expectVal {
+				t.Errorf("Got %v but expected %v", v, tc.expectVal)
+			}
+		})
+	}
+}
+
+func TestIsOvercommitAllowed(t *testing.T) {
+	testCases := []struct {
+		resourceName v1.ResourceName
+		expectVal    bool
+	}{
+		{
+			resourceName: "pod.alpha.kubernetes.io/opaque-int-resource-foo",
+			expectVal:    true,
+		},
+		{
+			resourceName: "kubernetes.io/resource-foo",
+			expectVal:    true,
+		},
+		{
+			resourceName: "hugepages-100m",
+			expectVal:    false,
+		},
+		{
+			resourceName: "",
+			expectVal:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("resourceName input=%s, expected value=%v", tc.resourceName, tc.expectVal), func(t *testing.T) {
+			t.Parallel()
+			v := IsOvercommitAllowed(tc.resourceName)
+			if v != tc.expectVal {
+				t.Errorf("Got %v but expected %v", v, tc.expectVal)
+			}
+		})
+	}
+}
+
+func TestGetAccessModesFromString(t *testing.T) {
+	modes := GetAccessModesFromString("ROX")
+	if !containsAccessMode(modes, v1.ReadOnlyMany) {
+		t.Errorf("Expected mode %s, but got %+v", v1.ReadOnlyMany, modes)
+	}
+
+	modes = GetAccessModesFromString("ROX,RWX")
+	if !containsAccessMode(modes, v1.ReadOnlyMany) {
+		t.Errorf("Expected mode %s, but got %+v", v1.ReadOnlyMany, modes)
+	}
+	if !containsAccessMode(modes, v1.ReadWriteMany) {
+		t.Errorf("Expected mode %s, but got %+v", v1.ReadWriteMany, modes)
+	}
+
+	modes = GetAccessModesFromString("RWO,ROX,RWX")
+	if !containsAccessMode(modes, v1.ReadOnlyMany) {
+		t.Errorf("Expected mode %s, but got %+v", v1.ReadOnlyMany, modes)
+	}
+	if !containsAccessMode(modes, v1.ReadWriteMany) {
+		t.Errorf("Expected mode %s, but got %+v", v1.ReadWriteMany, modes)
+	}
+}
+
+func TestRemoveDuplicateAccessModes(t *testing.T) {
+	modes := []v1.PersistentVolumeAccessMode{
+		v1.ReadWriteOnce, v1.ReadOnlyMany, v1.ReadOnlyMany, v1.ReadOnlyMany,
+	}
+	modes = removeDuplicateAccessModes(modes)
+	if len(modes) != 2 {
+		t.Errorf("Expected 2 distinct modes in set but found %v", len(modes))
+	}
+}
+
+func TestTopologySelectorRequirementsAsSelector(t *testing.T) {
+	mustParse := func(s string) labels.Selector {
+		out, e := labels.Parse(s)
+		if e != nil {
+			panic(e)
+		}
+		return out
+	}
+	tc := []struct {
+		in        []v1.TopologySelectorLabelRequirement
+		out       labels.Selector
+		expectErr bool
+	}{
+		{in: nil, out: labels.Nothing()},
+		{in: []v1.TopologySelectorLabelRequirement{}, out: labels.Nothing()},
+		{
+			in: []v1.TopologySelectorLabelRequirement{{
+				Key:    "foo",
+				Values: []string{"bar", "baz"},
+			}},
+			out: mustParse("foo in (baz,bar)"),
+		},
+		{
+			in: []v1.TopologySelectorLabelRequirement{{
+				Key:    "foo",
+				Values: []string{},
+			}},
+			expectErr: true,
+		},
+		{
+			in: []v1.TopologySelectorLabelRequirement{
+				{
+					Key:    "foo",
+					Values: []string{"bar", "baz"},
+				},
+				{
+					Key:    "invalid",
+					Values: []string{},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			in: []v1.TopologySelectorLabelRequirement{{
+				Key:    "/invalidkey",
+				Values: []string{"bar", "baz"},
+			}},
+			expectErr: true,
+		},
+	}
+
+	for i, tc := range tc {
+		out, err := TopologySelectorRequirementsAsSelector(tc.in)
+		if err == nil && tc.expectErr {
+			t.Errorf("[%v]expected error but got none.", i)
+		}
+		if err != nil && !tc.expectErr {
+			t.Errorf("[%v]did not expect error but got: %v", i, err)
+		}
+		if !reflect.DeepEqual(out, tc.out) {
+			t.Errorf("[%v]expected:\n\t%+v\nbut got:\n\t%+v", i, tc.out, out)
+		}
+	}
+}
+
+func TestTolerationsTolerateTaintsWithFilter(t *testing.T) {
+	testCases := []struct {
+		description     string
+		tolerations     []v1.Toleration
+		taints          []v1.Taint
+		applyFilter     taintsFilterFunc
+		expectTolerated bool
+	}{
+		{
+			description:     "empty tolerations tolerate empty taints",
+			tolerations:     []v1.Toleration{},
+			taints:          []v1.Taint{},
+			applyFilter:     func(t *v1.Taint) bool { return true },
+			expectTolerated: true,
+		},
+		{
+			description: "non-empty tolerations tolerate empty taints",
+			tolerations: []v1.Toleration{
+				{
+					Key:      "foo",
+					Operator: "Exists",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+			taints:          []v1.Taint{},
+			applyFilter:     func(t *v1.Taint) bool { return true },
+			expectTolerated: true,
+		},
+		{
+			description: "tolerations match all taints, expect tolerated",
+			tolerations: []v1.Toleration{
+				{
+					Key:      "foo",
+					Operator: "Exists",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+			taints: []v1.Taint{
+				{
+					Key:    "foo",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			applyFilter:     func(t *v1.Taint) bool { return true },
+			expectTolerated: true,
+		},
+		{
+			description: "tolerations don't match taints, but no taints apply to the filter, expect tolerated",
+			tolerations: []v1.Toleration{
+				{
+					Key:      "foo",
+					Operator: "Exists",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+			taints: []v1.Taint{
+				{
+					Key:    "bar",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			applyFilter:     func(t *v1.Taint) bool { return false },
+			expectTolerated: true,
+		},
+		{
+			description: "no filterFunc indicated, means all taints apply to the filter, tolerations don't match taints, expect untolerated",
+			tolerations: []v1.Toleration{
+				{
+					Key:      "foo",
+					Operator: "Exists",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+			taints: []v1.Taint{
+				{
+					Key:    "bar",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			applyFilter:     nil,
+			expectTolerated: false,
+		},
+		{
+			description: "tolerations match taints, expect tolerated",
+			tolerations: []v1.Toleration{
+				{
+					Key:      "foo",
+					Operator: "Exists",
+					Effect:   v1.TaintEffectNoExecute,
+				},
+			},
+			taints: []v1.Taint{
+				{
+					Key:    "foo",
+					Effect: v1.TaintEffectNoExecute,
+				},
+				{
+					Key:    "bar",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			applyFilter:     func(t *v1.Taint) bool { return t.Effect == v1.TaintEffectNoExecute },
+			expectTolerated: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		if tc.expectTolerated != TolerationsTolerateTaintsWithFilter(tc.tolerations, tc.taints, tc.applyFilter) {
+			filteredTaints := []v1.Taint{}
+			for _, taint := range tc.taints {
+				if tc.applyFilter != nil && !tc.applyFilter(&taint) {
+					continue
+				}
+				filteredTaints = append(filteredTaints, taint)
+			}
+			t.Errorf("[%s] expect tolerations %+v tolerate filtered taints %+v in taints %+v", tc.description, tc.tolerations, filteredTaints, tc.taints)
+		}
+	}
+}
+
+func TestGetAvoidPodsFromNode(t *testing.T) {
+	controllerFlag := true
+	testCases := []struct {
+		node        *v1.Node
+		expectValue v1.AvoidPods
+		expectErr   bool
+	}{
+		{
+			node:        &v1.Node{},
+			expectValue: v1.AvoidPods{},
+			expectErr:   false,
+		},
+		{
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						v1.PreferAvoidPodsAnnotationKey: `
+							{
+							    "preferAvoidPods": [
+							        {
+							            "podSignature": {
+							                "podController": {
+						                            "apiVersion": "v1",
+						                            "kind": "ReplicationController",
+						                            "name": "foo",
+						                            "uid": "abcdef123456",
+						                            "controller": true
+							                }
+							            },
+							            "reason": "some reason",
+							            "message": "some message"
+							        }
+							    ]
+							}`,
+					},
+				},
+			},
+			expectValue: v1.AvoidPods{
+				PreferAvoidPods: []v1.PreferAvoidPodsEntry{
+					{
+						PodSignature: v1.PodSignature{
+							PodController: &metav1.OwnerReference{
+								APIVersion: "v1",
+								Kind:       "ReplicationController",
+								Name:       "foo",
+								UID:        "abcdef123456",
+								Controller: &controllerFlag,
+							},
+						},
+						Reason:  "some reason",
+						Message: "some message",
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			node: &v1.Node{
+				// Missing end symbol of "podController" and "podSignature"
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						v1.PreferAvoidPodsAnnotationKey: `
+							{
+							    "preferAvoidPods": [
+							        {
+							            "podSignature": {
+							                "podController": {
+							                    "kind": "ReplicationController",
+							                    "apiVersion": "v1"
+							            "reason": "some reason",
+							            "message": "some message"
+							        }
+							    ]
+							}`,
+					},
+				},
+			},
+			expectValue: v1.AvoidPods{},
+			expectErr:   true,
+		},
+	}
+
+	for i, tc := range testCases {
+		v, err := GetAvoidPodsFromNodeAnnotations(tc.node.Annotations)
+		if err == nil && tc.expectErr {
+			t.Errorf("[%v]expected error but got none.", i)
+		}
+		if err != nil && !tc.expectErr {
+			t.Errorf("[%v]did not expect error but got: %v", i, err)
+		}
+		if !reflect.DeepEqual(tc.expectValue, v) {
+			t.Errorf("[%v]expect value %v but got %v with %v", i, tc.expectValue, v, v.PreferAvoidPods[0].PodSignature.PodController.Controller)
+		}
+	}
+}
+
+func TestMatchTopologySelectorTerms(t *testing.T) {
+	type args struct {
+		topologySelectorTerms []v1.TopologySelectorTerm
+		labels                labels.Set
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "nil term list",
+			args: args{
+				topologySelectorTerms: nil,
+				labels:                nil,
+			},
+			want: true,
+		},
+		{
+			name: "nil term",
+			args: args{
+				topologySelectorTerms: []v1.TopologySelectorTerm{
+					{
+						MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{},
+					},
+				},
+				labels: nil,
+			},
+			want: false,
+		},
+		{
+			name: "label matches MatchLabelExpressions terms",
+			args: args{
+				topologySelectorTerms: []v1.TopologySelectorTerm{
+					{
+						MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{{
+							Key:    "label_1",
+							Values: []string{"label_1_val"},
+						}},
+					},
+				},
+				labels: map[string]string{"label_1": "label_1_val"},
+			},
+			want: true,
+		},
+		{
+			name: "label does not match MatchLabelExpressions terms",
+			args: args{
+				topologySelectorTerms: []v1.TopologySelectorTerm{
+					{
+						MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{{
+							Key:    "label_1",
+							Values: []string{"label_1_val"},
+						}},
+					},
+				},
+				labels: map[string]string{"label_1": "label_1_val-failed"},
+			},
+			want: false,
+		},
+		{
+			name: "multi-values in one requirement, one matched",
+			args: args{
+				topologySelectorTerms: []v1.TopologySelectorTerm{
+					{
+						MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{{
+							Key:    "label_1",
+							Values: []string{"label_1_val1", "label_1_val2"},
+						}},
+					},
+				},
+				labels: map[string]string{"label_1": "label_1_val2"},
+			},
+			want: true,
+		},
+		{
+			name: "multi-terms was set, one matched",
+			args: args{
+				topologySelectorTerms: []v1.TopologySelectorTerm{
+					{
+						MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{{
+							Key:    "label_1",
+							Values: []string{"label_1_val"},
+						}},
+					},
+					{
+						MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{{
+							Key:    "label_2",
+							Values: []string{"label_2_val"},
+						}},
+					},
+				},
+				labels: map[string]string{
+					"label_2": "label_2_val",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "multi-requirement in one term, fully matched",
+			args: args{
+				topologySelectorTerms: []v1.TopologySelectorTerm{
+					{
+						MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+							{
+								Key:    "label_1",
+								Values: []string{"label_1_val"},
+							},
+							{
+								Key:    "label_2",
+								Values: []string{"label_2_val"},
+							},
+						},
+					},
+				},
+				labels: map[string]string{
+					"label_1": "label_1_val",
+					"label_2": "label_2_val",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "multi-requirement in one term, partial matched",
+			args: args{
+				topologySelectorTerms: []v1.TopologySelectorTerm{
+					{
+						MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+							{
+								Key:    "label_1",
+								Values: []string{"label_1_val"},
+							},
+							{
+								Key:    "label_2",
+								Values: []string{"label_2_val"},
+							},
+						},
+					},
+				},
+				labels: map[string]string{
+					"label_1": "label_1_val-failed",
+					"label_2": "label_2_val",
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MatchTopologySelectorTerms(tt.args.topologySelectorTerms, tt.args.labels); got != tt.want {
+				t.Errorf("MatchTopologySelectorTermsORed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNodeSelectorRequirementKeyExistsInNodeSelectorTerms(t *testing.T) {
+	tests := []struct {
+		name   string
+		reqs   []v1.NodeSelectorRequirement
+		terms  []v1.NodeSelectorTerm
+		exists bool
+	}{
+		{
+			name:   "empty set of keys in empty set of terms",
+			reqs:   []v1.NodeSelectorRequirement{},
+			terms:  []v1.NodeSelectorTerm{},
+			exists: false,
+		},
+		{
+			name: "key existence in terms with all keys specified",
+			reqs: []v1.NodeSelectorRequirement{
+				{
+					Key:      "key1",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"test-value1"},
+				},
+				{
+					Key:      "key2",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"test-value2"},
+				},
+			},
+			terms: []v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      "key2",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"test-value2"},
+						},
+						{
+							Key:      "key3",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"test-value3"},
+						},
+					},
+				},
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      "key1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"test-value11, test-value12"},
+						},
+						{
+							Key:      "key4",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"test-value41, test-value42"},
+						},
+					},
+				},
+			},
+			exists: true,
+		},
+		{
+			name: "key existence in terms with one of the keys specfied",
+			reqs: []v1.NodeSelectorRequirement{
+				{
+					Key:      "key1",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"test-value1"},
+				},
+				{
+					Key:      "key2",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"test-value2"},
+				},
+				{
+					Key:      "key3",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"test-value3"},
+				},
+				{
+					Key:      "key6",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"test-value6"},
+				},
+			},
+			terms: []v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      "key2",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"test-value2"},
+						}, {
+							Key:      "key4",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"test-value4"},
+						},
+					},
+				},
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      "key5",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"test-value5"},
+						},
+					},
+				},
+			},
+			exists: true,
+		},
+		{
+			name: "key existence in terms without any of the keys specified",
+			reqs: []v1.NodeSelectorRequirement{
+				{
+					Key:      "key2",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"test-value2"},
+				},
+				{
+					Key:      "key3",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"test-value3"},
+				},
+			},
+			terms: []v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      "key4",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"test-value"},
+						},
+						{
+							Key:      "key5",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"test-value"},
+						},
+					},
+				},
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      "key6",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"test-value"},
+						},
+					},
+				},
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      "key7",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"test-value"},
+						},
+						{
+							Key:      "key8",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"test-value"},
+						},
+					},
+				},
+			},
+			exists: false,
+		},
+		{
+			name: "key existence in empty set of terms",
+			reqs: []v1.NodeSelectorRequirement{
+				{
+					Key:      "key2",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"test-value2"},
+				},
+				{
+					Key:      "key3",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"test-value3"},
+				},
+			},
+			terms:  []v1.NodeSelectorTerm{},
+			exists: false,
+		},
+	}
+	for _, test := range tests {
+		keyExists := NodeSelectorRequirementKeysExistInNodeSelectorTerms(test.reqs, test.terms)
+		if test.exists != keyExists {
+			t.Errorf("test %s failed. Expected %v but got %v", test.name, test.exists, keyExists)
+		}
+	}
+}
+
+func TestHugePageUnitSizeFromByteSize(t *testing.T) {
+	tests := []struct {
+		size     int64
+		expected string
+		wantErr  bool
+	}{
+		{
+			size:     1024,
+			expected: "1KB",
+			wantErr:  false,
+		},
+		{
+			size:     33554432,
+			expected: "32MB",
+			wantErr:  false,
+		},
+		{
+			size:     3221225472,
+			expected: "3GB",
+			wantErr:  false,
+		},
+		{
+			size:     1024 * 1024 * 1023 * 3,
+			expected: "3069MB",
+			wantErr:  true,
+		},
+	}
+	for _, test := range tests {
+		size := test.size
+		result, err := HugePageUnitSizeFromByteSize(size)
+		if err != nil {
+			if test.wantErr {
+				t.Logf("HugePageUnitSizeFromByteSize() expected error = %v", err)
+			} else {
+				t.Errorf("HugePageUnitSizeFromByteSize() error = %v, wantErr %v", err, test.wantErr)
+			}
+			continue
+		}
+		if test.expected != result {
+			t.Errorf("HugePageUnitSizeFromByteSize() expected %v but got %v", test.expected, result)
+		}
+	}
+}
+
+func TestLoadBalancerStatusEqual(t *testing.T) {
+
+	testCases := []struct {
+		left      *v1.LoadBalancerStatus
+		right     *v1.LoadBalancerStatus
+		name      string
+		expectVal bool
+	}{{
+		name: "left equals right",
+		left: &v1.LoadBalancerStatus{
+			Ingress: []v1.LoadBalancerIngress{{
+				IP:       "1.1.1.1",
+				Hostname: "host1",
+			}},
+		},
+		right: &v1.LoadBalancerStatus{
+			Ingress: []v1.LoadBalancerIngress{{
+				IP:       "1.1.1.1",
+				Hostname: "host1",
+			}},
+		},
+		expectVal: true,
+	}, {
+		name: "length of LoadBalancerIngress slice is not equal",
+		left: &v1.LoadBalancerStatus{
+			Ingress: []v1.LoadBalancerIngress{{
+				IP:       "1.1.1.1",
+				Hostname: "host1",
+			}, {
+				IP:       "1.1.1.2",
+				Hostname: "host1",
+			}},
+		},
+		right: &v1.LoadBalancerStatus{
+			Ingress: []v1.LoadBalancerIngress{{
+				IP:       "1.1.1.1",
+				Hostname: "host1",
+			}},
+		},
+		expectVal: false,
+	}, {
+		name: "LoadBalancerIngress ip is not equal",
+		left: &v1.LoadBalancerStatus{
+			Ingress: []v1.LoadBalancerIngress{{
+				IP:       "1.1.1.2",
+				Hostname: "host1",
+			}},
+		},
+		right: &v1.LoadBalancerStatus{
+			Ingress: []v1.LoadBalancerIngress{{
+				IP:       "1.1.1.1",
+				Hostname: "host1",
+			}},
+		},
+		expectVal: false,
+	}, {
+		name: "LoadBalancerIngress hostname is not equal",
+		left: &v1.LoadBalancerStatus{
+			Ingress: []v1.LoadBalancerIngress{{
+				IP:       "1.1.1.1",
+				Hostname: "host2",
+			}},
+		},
+		right: &v1.LoadBalancerStatus{
+			Ingress: []v1.LoadBalancerIngress{{
+				IP:       "1.1.1.1",
+				Hostname: "host1",
+			}},
+		},
+		expectVal: false,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := LoadBalancerStatusEqual(tc.left, tc.right)
+			if v != tc.expectVal {
+				t.Errorf("test %s failed. left input=%v, right input=%v, Got %v but expected %v",
+					tc.name, tc.left, tc.right, v, tc.expectVal)
+			}
+		})
+	}
+}

--- a/internal/podutils/env.go
+++ b/internal/podutils/env.go
@@ -21,6 +21,9 @@ import (
 	"strings"
 
 	"github.com/virtual-kubelet/virtual-kubelet/internal/expansion"
+	fieldpath "github.com/virtual-kubelet/virtual-kubelet/internal/kubernetes/fieldpath"
+	podshelper "github.com/virtual-kubelet/virtual-kubelet/internal/kubernetes/pods"
+	v1helper "github.com/virtual-kubelet/virtual-kubelet/internal/kubernetes/v1/helper"
 	"github.com/virtual-kubelet/virtual-kubelet/internal/manager"
 	"github.com/virtual-kubelet/virtual-kubelet/log"
 	corev1 "k8s.io/api/core/v1"
@@ -29,9 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	apivalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/record"
-	podshelper "k8s.io/kubernetes/pkg/apis/core/pods"
-	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
-	fieldpath "k8s.io/kubernetes/pkg/fieldpath"
 	"k8s.io/kubernetes/pkg/kubelet/envvars"
 	"k8s.io/utils/pointer"
 )


### PR DESCRIPTION
Put 3 k8s.io/kubernetes packages in internal/kubernetes to prevent
depending on k8s.io/kubernetes

See: #940

Probably depends on the merge of #945

Signed-off-by: Miek Gieben <miek@miek.nl>
