### PR TITLE
Add logging to help debug queueing problems

### DIFF
--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -364,6 +364,7 @@ func (q *Queue) getNextItem(ctx context.Context) (*queueItem, error) {
 func (q *Queue) handleQueueItem(ctx context.Context) bool {
 	ctx, span := trace.StartSpan(ctx, "handleQueueItem")
 	defer span.End()
+	ctx = log.WithLogger(ctx, log.G(ctx).WithField("queue", q.name))
 
 	qi, err := q.getNextItem(ctx)
 	if err != nil {
@@ -376,6 +377,7 @@ func (q *Queue) handleQueueItem(ctx context.Context) bool {
 	// We do this as the delayed nature of the work Queue means the items in the informer cache may actually be more u
 	// to date that when the item was initially put onto the workqueue.
 	ctx = span.WithField(ctx, "key", qi.key)
+	ctx = log.WithLogger(ctx, log.G(ctx).WithField("key", qi.key))
 	log.G(ctx).Debug("Got Queue object")
 
 	err = q.handleQueueItemObject(ctx, qi)

--- a/node/podcontroller.go
+++ b/node/podcontroller.go
@@ -547,6 +547,7 @@ func (pc *PodController) syncPodInProvider(ctx context.Context, pod *corev1.Pod,
 		}
 
 		key = fmt.Sprintf("%v/%v", key, pod.UID)
+		log.G(ctx).WithField("seconds", *pod.DeletionGracePeriodSeconds).Debug("Enqueued pod for deletion in Kubernetes")
 		pc.deletePodsFromKubernetes.EnqueueWithoutRateLimitWithDelay(ctx, key, time.Second*time.Duration(*pod.DeletionGracePeriodSeconds))
 		return nil
 	}


### PR DESCRIPTION
This adds *logs* for information about which queue is
being used / invoked. Previously this information was
in traces.

Signed-off-by: Sargun Dhillon <sargun@sargun.me>