### PR TITLE
fix jaeger deprecated config

### DIFF
--- a/cmd/virtual-kubelet/internal/commands/root/tracing_register_jaeger.go
+++ b/cmd/virtual-kubelet/internal/commands/root/tracing_register_jaeger.go
@@ -43,7 +43,7 @@ func NewJaegerExporter(opts TracingExporterOptions) (trace.Exporter, error) {
 	}
 
 	if jOpts.Endpoint != "" && jOpts.CollectorEndpoint == "" { // nolintlint:staticcheck
-		jOpts.CollectorEndpoint = fmt.Sprintf("%s/api/traces", jOpts.Endpoint)
+		jOpts.CollectorEndpoint = fmt.Sprintf("%s/api/traces", jOpts.Endpoint) // nolintlint:staticcheck
 	}
 	if jOpts.CollectorEndpoint == "" && jOpts.AgentEndpoint == "" { // nolintlint:staticcheck
 		return nil, errors.New("Must specify either JAEGER_COLLECTOR_ENDPOINT or JAEGER_AGENT_ENDPOINT")

--- a/cmd/virtual-kubelet/internal/commands/root/tracing_register_jaeger.go
+++ b/cmd/virtual-kubelet/internal/commands/root/tracing_register_jaeger.go
@@ -42,10 +42,10 @@ func NewJaegerExporter(opts TracingExporterOptions) (trace.Exporter, error) {
 		},
 	}
 
-	if jOpts.Endpoint != "" && jOpts.CollectorEndpoint == "" {
+	if jOpts.Endpoint != "" && jOpts.CollectorEndpoint == "" { // nolintlint:staticcheck
 		jOpts.CollectorEndpoint = fmt.Sprintf("%s/api/traces", jOpts.Endpoint)
 	}
-	if jOpts.CollectorEndpoint == "" && jOpts.AgentEndpoint == "" { // nolint:staticcheck
+	if jOpts.CollectorEndpoint == "" && jOpts.AgentEndpoint == "" { // nolintlint:staticcheck
 		return nil, errors.New("Must specify either JAEGER_COLLECTOR_ENDPOINT or JAEGER_AGENT_ENDPOINT")
 	}
 


### PR DESCRIPTION
jaeger's config `Endpoint` has been deprecated:

```go
// Options are the options to be used when initializing a Jaeger exporter.
type Options struct {
	// Endpoint is the Jaeger HTTP Thrift endpoint.
	// For example, http://localhost:14268.
	//
	// Deprecated: Use CollectorEndpoint instead.
	Endpoint string
 ...
```

so fix must specify check condition.