### PR TITLE
Return early on ping error

### DIFF
--- a/node/lease_controller_v1.go
+++ b/node/lease_controller_v1.go
@@ -114,6 +114,7 @@ func (c *leaseController) sync(ctx context.Context) {
 	pingResult, err := c.nodeController.nodePingController.getResult(ctx)
 	if err != nil {
 		log.G(ctx).WithError(err).Error("Could not get ping status")
+		return
 	}
 	if pingResult.error != nil {
 		log.G(ctx).WithError(pingResult.error).Error("Ping result is not clean, not updating lease")

--- a/node/sync.go
+++ b/node/sync.go
@@ -134,7 +134,12 @@ func (p *syncProviderWrapper) syncPodStatuses(ctx context.Context) {
 
 	for _, pod := range pods {
 		if shouldSkipPodStatusUpdate(pod) {
-			log.G(ctx).Debug("Skipping pod status update")
+			log.G(ctx).WithFields(log.Fields{
+				"pod":       pod.Name,
+				"namespace": pod.Namespace,
+				"phase":     pod.Status.Phase,
+				"status":    pod.Status.Reason,
+			}).Debug("Skipping pod status update")
 			continue
 		}
 


### PR DESCRIPTION
Found that this caused a panic after many many test runs.
It seems like we should have returned early since the pingResult is nil.
We don't want to update a lease when ping fails.