### PR TITLE
Change klog flag version to v2

### DIFF
--- a/cmd/virtual-kubelet/internal/commands/root/flag.go
+++ b/cmd/virtual-kubelet/internal/commands/root/flag.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 type mapVar map[string]string


### PR DESCRIPTION
Client-go v0.19 needs to be used with klog/v2, but the flagSet of virtual-kubelet still uses klog (v1), which will cause if client-go needs to be debugged, setting the klog flag has no effect