### PR TITLE
fix(*): update pod status func change to patch

### DIFF
--- a/node/pod_test.go
+++ b/node/pod_test.go
@@ -274,6 +274,7 @@ func TestPodStatusDelete(t *testing.T) {
 	pod := &corev1.Pod{}
 	pod.ObjectMeta.Namespace = "default"
 	pod.ObjectMeta.Name = "nginx"
+	pod.ObjectMeta.UID = "00000000-0000-0000-0000-00000000000"
 	pod.Spec = newPodSpec()
 	fk8s := fake.NewSimpleClientset(pod)
 	c.client = fk8s


### PR DESCRIPTION
Currently, VK uses the `UpdatePodStatus` method to update Pod Status, which updates the Pod metadata part synchronously.
For example, if the user manually modified the Pod's label or annotation when updating the Pod Status, this modification will be overwritten.
Refer to the kubelet implementation and replace the UpdatePodStatus method with the Patch method.

refer to:
https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/status/status_manager.go#L623
https://github.com/kubernetes/kubernetes/blob/master/pkg/util/pod/pod.go#L33