### PR TITLE
Support environment variable values from 'status.hostIP', 'status.podIP' and 'status.podIPs'

### DIFF
--- a/internal/podutils/env.go
+++ b/internal/podutils/env.go
@@ -495,6 +495,19 @@ func podFieldSelectorRuntimeValue(fs *corev1.ObjectFieldSelector, pod *corev1.Po
 		return pod.Status.HostIP, nil
 	case "status.podIP":
 		return pod.Status.PodIP, nil
+	case "status.podIPs":
+		podIPs := pod.Status.PodIPs
+		var buffer strings.Builder
+		for i := range podIPs {
+			buffer.WriteString(podIPs[i].IP)
+			buffer.WriteByte(',')
+		}
+		n := buffer.Len()
+		if n == 0 {
+			return "", nil
+		}
+		podIPsStr := buffer.String()[:n-1]
+		return podIPsStr, nil
 	}
 	return ExtractFieldPathAsString(pod, internalFieldPath)
 }

--- a/internal/podutils/env.go
+++ b/internal/podutils/env.go
@@ -491,7 +491,10 @@ func podFieldSelectorRuntimeValue(fs *corev1.ObjectFieldSelector, pod *corev1.Po
 		return pod.Spec.NodeName, nil
 	case "spec.serviceAccountName":
 		return pod.Spec.ServiceAccountName, nil
-
+	case "status.hostIP":
+		return pod.Status.HostIP, nil
+	case "status.podIP":
+		return pod.Status.PodIP, nil
 	}
 	return ExtractFieldPathAsString(pod, internalFieldPath)
 }

--- a/internal/podutils/env_internal_test.go
+++ b/internal/podutils/env_internal_test.go
@@ -49,6 +49,8 @@ const (
 	envVarName5 = "XXX"
 	// envVarName6 is a string that can be used as the name of an environment value.
 	envVarName6 = "YYY"
+	// envVarName7 is a string that can be used as the name of an environment value.
+	envVarName7 = "ZZZ"
 	// invalidKey1 is a key that cannot be used as the name of an environment variable (since it starts with a digit).
 	invalidKey1 = "1INVALID"
 	// invalidKey2 is a key that cannot be used as the name of an environment variable (since it starts with a digit).
@@ -347,6 +349,15 @@ func TestPopulatePodWithInitContainersUsingEnvWithFieldRef(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: envVarName7,
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1",
+									FieldPath:  "status.podIPs",
+								},
+							},
+						},
 					},
 				},
 			},
@@ -407,6 +418,15 @@ func TestPopulatePodWithInitContainersUsingEnvWithFieldRef(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: envVarName7,
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1",
+									FieldPath:  "status.podIPs",
+								},
+							},
+						},
 					},
 				},
 			},
@@ -415,6 +435,10 @@ func TestPopulatePodWithInitContainersUsingEnvWithFieldRef(t *testing.T) {
 		Status: corev1.PodStatus{
 			HostIP: "1.2.3.4",
 			PodIP:  "5.6.7.8",
+			PodIPs: []corev1.PodIP{
+				{IP: "5.6.7.8"},
+				{IP: "a00:100::4"},
+			},
 		},
 	}
 
@@ -449,6 +473,10 @@ func TestPopulatePodWithInitContainersUsingEnvWithFieldRef(t *testing.T) {
 			Name:  envVarName6,
 			Value: "5.6.7.8",
 		},
+		{
+			Name:  envVarName7,
+			Value: "5.6.7.8,a00:100::4",
+		},
 	}, sortOpt))
 
 	assert.Check(t, is.DeepEqual(pod.Spec.Containers[0].Env, []corev1.EnvVar{
@@ -476,6 +504,10 @@ func TestPopulatePodWithInitContainersUsingEnvWithFieldRef(t *testing.T) {
 		{
 			Name:  envVarName6,
 			Value: "5.6.7.8",
+		},
+		{
+			Name:  envVarName7,
+			Value: "5.6.7.8,a00:100::4",
 		},
 	}, sortOpt))
 }

--- a/internal/podutils/env_internal_test.go
+++ b/internal/podutils/env_internal_test.go
@@ -45,6 +45,10 @@ const (
 	envVarName3 = "CHO"
 	// envVarName4 is a string that can be used as the name of an environment value.
 	envVarName4 = "CAR"
+	// envVarName5 is a string that can be used as the name of an environment value.
+	envVarName5 = "XXX"
+	// envVarName6 is a string that can be used as the name of an environment value.
+	envVarName6 = "YYY"
 	// invalidKey1 is a key that cannot be used as the name of an environment variable (since it starts with a digit).
 	invalidKey1 = "1INVALID"
 	// invalidKey2 is a key that cannot be used as the name of an environment variable (since it starts with a digit).
@@ -325,6 +329,24 @@ func TestPopulatePodWithInitContainersUsingEnvWithFieldRef(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: envVarName5,
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1",
+									FieldPath:  "status.hostIP",
+								},
+							},
+						},
+						{
+							Name: envVarName6,
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1",
+									FieldPath:  "status.podIP",
+								},
+							},
+						},
 					},
 				},
 			},
@@ -367,10 +389,32 @@ func TestPopulatePodWithInitContainersUsingEnvWithFieldRef(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: envVarName5,
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1",
+									FieldPath:  "status.hostIP",
+								},
+							},
+						},
+						{
+							Name: envVarName6,
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1",
+									FieldPath:  "status.podIP",
+								},
+							},
+						},
 					},
 				},
 			},
 			EnableServiceLinks: &bFalse,
+		},
+		Status: corev1.PodStatus{
+			HostIP: "1.2.3.4",
+			PodIP:  "5.6.7.8",
 		},
 	}
 
@@ -397,6 +441,14 @@ func TestPopulatePodWithInitContainersUsingEnvWithFieldRef(t *testing.T) {
 			Name:  envVarName4,
 			Value: "serviceaccount",
 		},
+		{
+			Name:  envVarName5,
+			Value: "1.2.3.4",
+		},
+		{
+			Name:  envVarName6,
+			Value: "5.6.7.8",
+		},
 	}, sortOpt))
 
 	assert.Check(t, is.DeepEqual(pod.Spec.Containers[0].Env, []corev1.EnvVar{
@@ -416,6 +468,14 @@ func TestPopulatePodWithInitContainersUsingEnvWithFieldRef(t *testing.T) {
 		{
 			Name:  envVarName4,
 			Value: "serviceaccount",
+		},
+		{
+			Name:  envVarName5,
+			Value: "1.2.3.4",
+		},
+		{
+			Name:  envVarName6,
+			Value: "5.6.7.8",
 		},
 	}, sortOpt))
 }


### PR DESCRIPTION
'status.hostIP', 'status.podIP' and 'status.podIPs' are available to containers through environment variables.

Refer to: https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/