### PR TITLE
Removed deprecated node Clustername

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -685,10 +685,9 @@ func (t taintsStringer) String() string {
 
 func addNodeAttributes(ctx context.Context, span trace.Span, n *corev1.Node) context.Context {
 	return span.WithFields(ctx, log.Fields{
-		"node.UID":     string(n.UID),
-		"node.name":    n.Name,
-		"node.cluster": n.ClusterName,
-		"node.taints":  taintsStringer(n.Spec.Taints),
+		"node.UID":    string(n.UID),
+		"node.name":   n.Name,
+		"node.taints": taintsStringer(n.Spec.Taints),
 	})
 }
 


### PR DESCRIPTION
With this one line, vk fails to build against k8s 1.24 libs.

The comment says:

    // Deprecated: ClusterName is a legacy field that was always cleared by
    // the system and never used; it will be removed completely in 1.25.

Seems to be removed in 1.24 though.

----

There are other PRs like #1001 and #1373, but all I really need is to make sure it compiles when used as a library.