### PR TITLE
Only run codeql on pushes to master, not pr's

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,9 +7,6 @@ concurrency:
 on:
   push:
     branches: [master]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [master]
   schedule:
     - cron: "19 18 * * 3"
 


### PR DESCRIPTION
These are extremely slow and probably very expensive for someone.
We don't need these running on PR's which have constant pushes, rebases,
etc.

The activity on the repo is slow enough we can fix-up things after
codeql runs on master.