### PR TITLE
codeql: Add explicit permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,8 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Codeql requires write access to security-events, but our default action token (rightly) only has read permissions.
This adds the explicit request for write access.

Relevant issue: https://github.com/github/codeql-action/issues/464#issuecomment-828811531