### PR TITLE
Support Kind in Makefile check

### DIFF
--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -1,3 +1,10 @@
+
+# skaffold checks for kubectl context
+# For minikube, docker-for-desktop and docker-desktop the context matches above names
+# If one wants to use kind, kind gives context names based on the cluster-name
+# But as of now they match the following syntax: kind-*
+# The first check verifies that this is a kind kubernetes context
+# Second check verifies the other ones
 .PHONY: skaffold.validate
 skaffold.validate: kubectl_context := $(shell kubectl config current-context)
 skaffold.validate:

--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -1,7 +1,10 @@
 .PHONY: skaffold.validate
 skaffold.validate: kubectl_context := $(shell kubectl config current-context)
 skaffold.validate:
-	@if [[ ! "minikube,docker-for-desktop,docker-desktop" =~ .*"$(kubectl_context)".* ]]; then \
+
+	@if [[ "$(kubectl_context)" =~ .*"kind".* ]]; then \
+		true; \
+	elif [[ ! "minikube,docker-for-desktop,docker-desktop" =~ .*"$(kubectl_context)".* ]]; then \
 		echo current-context is [$(kubectl_context)]. Must be one of [minikube,docker-for-desktop,docker-desktop]; \
 		false; \
 	fi


### PR DESCRIPTION
I was trying to play around with `virtual-kubelet` and I see that there is a check for kubectl context against docker-desktop and minikube.  

I tend to like to use `kind` so I am attempting to use it for virtual-kubelet testing.  

This is my first issue I discovered when running `make`.  

Generally, kind has a context that is the following `kind-$KIND-CLUSTER-NAME$` so I do a regular expression check against context.