### PR TITLE
fix provider in the nodeutil in the https://github.com/virtual-kubele…

### DIFF
--- a/cmd/virtual-kubelet/internal/provider/mock/mock.go
+++ b/cmd/virtual-kubelet/internal/provider/mock/mock.go
@@ -308,6 +308,11 @@ func (p *MockProvider) AttachToContainer(ctx context.Context, namespace, name, c
 	return nil
 }
 
+func (p *MockProvider) PortForward(ctx context.Context, namespace, pod string, port int32, stream io.ReadWriteCloser) error {
+	log.G(ctx).Infof("receive PortForward %q", pod)
+	return nil
+}
+
 // GetPodStatus returns the status of a pod by name that is "running".
 // returns nil if a pod by that name is not found.
 func (p *MockProvider) GetPodStatus(ctx context.Context, namespace, name string) (*v1.PodStatus, error) {

--- a/node/nodeutil/provider.go
+++ b/node/nodeutil/provider.go
@@ -37,6 +37,9 @@ type Provider interface {
 
 	// GetMetricsResource gets the metrics for the node, including running pods
 	GetMetricsResource(context.Context) ([]*dto.MetricFamily, error)
+
+	// PortForward forwards a local port to a port on the pod
+	PortForward(ctx context.Context, namespace, pod string, port int32, stream io.ReadWriteCloser) error
 }
 
 // ProviderConfig holds objects created by NewNodeFromClient that a provider may need to bootstrap itself.
@@ -73,6 +76,7 @@ func AttachProviderRoutes(mux api.ServeMux) NodeOpt {
 				GetMetricsResource:    p.GetMetricsResource,
 				StreamIdleTimeout:     cfg.StreamIdleTimeout,
 				StreamCreationTimeout: cfg.StreamCreationTimeout,
+				PortForward:      p.PortForward,
 			}, true))
 		}
 		return nil


### PR DESCRIPTION
   When I was using this https://github.com/virtual-kubelet/virtual-kubelet/pull/1102 about portforward, I found that the function definition of portforward had not been added to the provider's interface definition. This resulted in the portforward feature not being implemented when using virtual-kubelet as a node.

   please reivew this fix with the pr https://github.com/virtual-kubelet/virtual-kubelet/pull/1102