### PR TITLE
Add error handler to recreate virtual node when it's deleted

### DIFF
--- a/node/nodeutil/controller.go
+++ b/node/nodeutil/controller.go
@@ -372,7 +372,7 @@ func NewNode(name string, newProvider NewProviderFunc, opts ...NodeOpt) (*Node, 
 		node.WithNodeEnableLeaseV1(NodeLeaseV1Client(cfg.Client), node.DefaultLeaseDuration),
 	}
 
-	if(cfg.NodeStatusUpdateErrorHandler != nil) {
+	if cfg.NodeStatusUpdateErrorHandler != nil {
 		nodeControllerOpts = append(nodeControllerOpts, node.WithNodeStatusUpdateErrorHandler(cfg.NodeStatusUpdateErrorHandler))
 	}
 


### PR DESCRIPTION
Currently the virtual node is created during virtual kubelet start up. We hit a situation that the virtual node might be deleted by kubernetes control plane due to lost heartbeat. The virtual node won't be recovered until we restart the virtual kubelet.

This PR adds an error handler to nodeController so it has a chance to recreate the node when the virtual node is gone.