### PR TITLE
feat: Add methods to get length of PodController queues

### DIFF
--- a/node/podcontroller.go
+++ b/node/podcontroller.go
@@ -453,6 +453,21 @@ func (pc *PodController) Err() error {
 	return pc.err
 }
 
+// SyncPodsFromKubernetesQueueLen returns the length of the SyncPodsFromKubernetes queue
+func (pc *PodController) SyncPodsFromKubernetesQueueLen() int {
+	return pc.syncPodsFromKubernetes.Len()
+}
+
+// DeletePodsFromKubernetesQueueLen returns the length of the DeletePodsFromKubernetes queue
+func (pc *PodController) DeletePodsFromKubernetesQueueLen() int {
+	return pc.deletePodsFromKubernetes.Len()
+}
+
+// SyncPodStatusFromProviderQueueLen returns the length of the SyncPodStatusFromProvider queue
+func (pc *PodController) SyncPodStatusFromProviderQueueLen() int {
+	return pc.syncPodStatusFromProvider.Len()
+}
+
 // syncPodFromKubernetesHandler compares the actual state with the desired, and attempts to converge the two.
 func (pc *PodController) syncPodFromKubernetesHandler(ctx context.Context, key string) error {
 	ctx, span := trace.StartSpan(ctx, "syncPodFromKubernetesHandler")


### PR DESCRIPTION
This PR adds three new methods to the PodController struct. These methods return the current length of the SyncPodsFromKubernetes, DeletePodsFromKubernetes, and SyncPodStatusFromProvider queues, respectively. These methods will provide valuable insights into the queue sizes, which can be used for monitoring and performance tuning.

At Netflix, we are working on tuning the PodController rate limiter and we need insights into the queue size.