### PR TITLE
Make field reference resolution best effort

### DIFF
--- a/internal/podutils/env_internal_test.go
+++ b/internal/podutils/env_internal_test.go
@@ -45,6 +45,8 @@ const (
 	envVarName3 = "CHO"
 	// envVarName4 is a string that can be used as the name of an environment value.
 	envVarName4 = "CAR"
+	// envVarName5 is a string that can be used as the name of an environment value.
+	envVarName5 = "FLO"
 	// invalidKey1 is a key that cannot be used as the name of an environment variable (since it starts with a digit).
 	invalidKey1 = "1INVALID"
 	// invalidKey2 is a key that cannot be used as the name of an environment variable (since it starts with a digit).
@@ -325,6 +327,15 @@ func TestPopulatePodWithInitContainersUsingEnvWithFieldRef(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: envVarName5,
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1",
+									FieldPath:  "status.hostIP",
+								},
+							},
+						},
 					},
 				},
 			},
@@ -367,6 +378,15 @@ func TestPopulatePodWithInitContainersUsingEnvWithFieldRef(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: envVarName5,
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1",
+									FieldPath:  "status.hostIP",
+								},
+							},
+						},
 					},
 				},
 			},
@@ -397,6 +417,10 @@ func TestPopulatePodWithInitContainersUsingEnvWithFieldRef(t *testing.T) {
 			Name:  envVarName4,
 			Value: "serviceaccount",
 		},
+		{
+			Name:  envVarName5,
+			Value: "status.hostIP",
+		},
 	}, sortOpt))
 
 	assert.Check(t, is.DeepEqual(pod.Spec.Containers[0].Env, []corev1.EnvVar{
@@ -416,6 +440,10 @@ func TestPopulatePodWithInitContainersUsingEnvWithFieldRef(t *testing.T) {
 		{
 			Name:  envVarName4,
 			Value: "serviceaccount",
+		},
+		{
+			Name:  envVarName5,
+			Value: "status.hostIP",
 		},
 	}, sortOpt))
 }

--- a/internal/podutils/helper.go
+++ b/internal/podutils/helper.go
@@ -75,6 +75,7 @@ func ExtractFieldPathAsString(obj interface{}, fieldPath string) (string, error)
 	if err != nil {
 		return "", err
 	}
+	// TODO if provider had some sort of method for handling this, we'd need that reference here
 
 	if path, subscript, ok := SplitMaybeSubscriptedPath(fieldPath); ok {
 		switch path {
@@ -106,7 +107,8 @@ func ExtractFieldPathAsString(obj interface{}, fieldPath string) (string, error)
 		return string(accessor.GetUID()), nil
 	}
 
-	return "", fmt.Errorf("unsupported fieldPath: %v", fieldPath)
+	return fieldPath, nil
+	// return "", fmt.Errorf("unsupported fieldPath: %v", fieldPath)
 }
 
 // SplitMaybeSubscriptedPath checks whether the specified fieldPath is

--- a/internal/podutils/helper.go
+++ b/internal/podutils/helper.go
@@ -75,7 +75,6 @@ func ExtractFieldPathAsString(obj interface{}, fieldPath string) (string, error)
 	if err != nil {
 		return "", err
 	}
-	// TODO if provider had some sort of method for handling this, we'd need that reference here
 
 	if path, subscript, ok := SplitMaybeSubscriptedPath(fieldPath); ok {
 		switch path {
@@ -108,7 +107,6 @@ func ExtractFieldPathAsString(obj interface{}, fieldPath string) (string, error)
 	}
 
 	return fieldPath, nil
-	// return "", fmt.Errorf("unsupported fieldPath: %v", fieldPath)
 }
 
 // SplitMaybeSubscriptedPath checks whether the specified fieldPath is

--- a/node/nodeutil/controller.go
+++ b/node/nodeutil/controller.go
@@ -254,6 +254,11 @@ type NodeConfig struct {
 	// Set the error handler for node status update failures
 	NodeStatusUpdateErrorHandler node.ErrorHandler
 
+	// SkipDownwardAPIResolution can be used to skip any attempts at resolving downward API references
+	// in pods before calling CreatePod on the provider.
+	// Providers need this if they need to do their own custom resolving
+	SkipDownwardAPIResolution bool
+
 	routeAttacher func(Provider, NodeConfig, corev1listers.PodLister)
 }
 
@@ -393,13 +398,14 @@ func NewNode(name string, newProvider NewProviderFunc, opts ...NodeOpt) (*Node, 
 	}
 
 	pc, err := node.NewPodController(node.PodControllerConfig{
-		PodClient:         cfg.Client.CoreV1(),
-		EventRecorder:     cfg.EventRecorder,
-		Provider:          p,
-		PodInformer:       podInformer,
-		SecretInformer:    secretInformer,
-		ConfigMapInformer: configMapInformer,
-		ServiceInformer:   serviceInformer,
+		PodClient:                 cfg.Client.CoreV1(),
+		EventRecorder:             cfg.EventRecorder,
+		Provider:                  p,
+		PodInformer:               podInformer,
+		SecretInformer:            secretInformer,
+		ConfigMapInformer:         configMapInformer,
+		ServiceInformer:           serviceInformer,
+		SkipDownwardAPIResolution: cfg.SkipDownwardAPIResolution,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating pod controller")

--- a/node/pod.go
+++ b/node/pod.go
@@ -69,11 +69,13 @@ func (pc *PodController) createOrUpdatePod(ctx context.Context, pod *corev1.Pod)
 		"namespace": pod.GetNamespace(),
 	})
 
-	// We do this so we don't mutate the pod from the informer cache
-	pod = pod.DeepCopy()
-	if err := podutils.PopulateEnvironmentVariables(ctx, pod, pc.resourceManager, pc.recorder); err != nil {
-		span.SetStatus(err)
-		return err
+	if !pc.skipDownwardAPIResolution {
+		// We do this so we don't mutate the pod from the informer cache
+		pod = pod.DeepCopy()
+		if err := podutils.PopulateEnvironmentVariables(ctx, pod, pc.resourceManager, pc.recorder); err != nil {
+			span.SetStatus(err)
+			return err
+		}
 	}
 
 	// We have to use a  different pod that we pass to the provider than the one that gets used in handleProviderError


### PR DESCRIPTION
Today, VK tries to resolve field references for the provider before calling CreatePod. However, if it doesn't know how to resolve a particular field reference, VK core errors out and never calls CreatePod. I think this is a bug - here is the behavior seen by application owners if they see this issue hit:

1) workloads are running fine
2) add unsupported field reference (e.g. status.hostIP)
3) workloads will schedule as usual on VK, but pods will now sit in pending state indefinitely since the pods are assigned a node

Ultimately I think [this](https://github.com/virtual-kubelet/virtual-kubelet/issues/1032) is the right thing to do to offload much of the effort of resolving these field references based on provider needs, but with or without that I still think the current behavior should be considered a bug and fixed.