### PR TITLE
Allow providers to skip VK downward API resolution

### DIFF
--- a/node/nodeutil/controller.go
+++ b/node/nodeutil/controller.go
@@ -254,6 +254,11 @@ type NodeConfig struct {
 	// Set the error handler for node status update failures
 	NodeStatusUpdateErrorHandler node.ErrorHandler
 
+	// SkipDownwardAPIResolution can be used to skip any attempts at resolving downward API references
+	// in pods before calling CreatePod on the provider.
+	// Providers need this if they need to do their own custom resolving
+	SkipDownwardAPIResolution bool
+
 	routeAttacher func(Provider, NodeConfig, corev1listers.PodLister)
 }
 
@@ -393,13 +398,14 @@ func NewNode(name string, newProvider NewProviderFunc, opts ...NodeOpt) (*Node, 
 	}
 
 	pc, err := node.NewPodController(node.PodControllerConfig{
-		PodClient:         cfg.Client.CoreV1(),
-		EventRecorder:     cfg.EventRecorder,
-		Provider:          p,
-		PodInformer:       podInformer,
-		SecretInformer:    secretInformer,
-		ConfigMapInformer: configMapInformer,
-		ServiceInformer:   serviceInformer,
+		PodClient:                 cfg.Client.CoreV1(),
+		EventRecorder:             cfg.EventRecorder,
+		Provider:                  p,
+		PodInformer:               podInformer,
+		SecretInformer:            secretInformer,
+		ConfigMapInformer:         configMapInformer,
+		ServiceInformer:           serviceInformer,
+		SkipDownwardAPIResolution: cfg.SkipDownwardAPIResolution,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating pod controller")

--- a/node/pod.go
+++ b/node/pod.go
@@ -69,11 +69,13 @@ func (pc *PodController) createOrUpdatePod(ctx context.Context, pod *corev1.Pod)
 		"namespace": pod.GetNamespace(),
 	})
 
-	// We do this so we don't mutate the pod from the informer cache
-	pod = pod.DeepCopy()
-	if err := podutils.PopulateEnvironmentVariables(ctx, pod, pc.resourceManager, pc.recorder); err != nil {
-		span.SetStatus(err)
-		return err
+	if !pc.skipDownwardAPIResolution {
+		// We do this so we don't mutate the pod from the informer cache
+		pod = pod.DeepCopy()
+		if err := podutils.PopulateEnvironmentVariables(ctx, pod, pc.resourceManager, pc.recorder); err != nil {
+			span.SetStatus(err)
+			return err
+		}
 	}
 
 	// We have to use a  different pod that we pass to the provider than the one that gets used in handleProviderError


### PR DESCRIPTION
Currently, VK attempts to resolve downward APIs before calling the provider's CreatePod or UpdatePod implementation. However, there are valid reasons a provider may want to do downward API resolution themselves.

This is a logical first step to expose downward resolution utilities to providers as discussed [here](https://github.com/virtual-kubelet/virtual-kubelet/issues/1032)