### PR TITLE
fix: enable lll linter and format long function signatures

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,3 @@
-linter-settings:
-  lll:
-    line-length: 200
-
 timeout: 10m
 
 issues:
@@ -30,8 +26,11 @@ linters:
     - gosec
     - copyloopvar # Checks for pointers to enclosing loop variables
     - tenv # Detects using os.Setenv instead of t.Setenv since Go 1.17
+    - lll
 
 linters-settings:
   gosec:
     excludes:
       - G304 # Potential file inclusion via variable
+  lll:
+    line-length: 200

--- a/internal/manager/resource.go
+++ b/internal/manager/resource.go
@@ -32,7 +32,12 @@ type ResourceManager struct {
 }
 
 // NewResourceManager returns a ResourceManager with the internal maps initialized.
-func NewResourceManager(podLister corev1listers.PodLister, secretLister corev1listers.SecretLister, configMapLister corev1listers.ConfigMapLister, serviceLister corev1listers.ServiceLister) (*ResourceManager, error) {
+func NewResourceManager(
+	podLister corev1listers.PodLister,
+	secretLister corev1listers.SecretLister,
+	configMapLister corev1listers.ConfigMapLister,
+	serviceLister corev1listers.ServiceLister,
+) (*ResourceManager, error) {
 	rm := ResourceManager{
 		podLister:       podLister,
 		secretLister:    secretLister,

--- a/node/api/attach.go
+++ b/node/api/attach.go
@@ -95,7 +95,16 @@ type containerAttachContext struct {
 
 // AttachToContainer Implements remotecommand.Attacher
 // This is called by remotecommand.ServeAttach
-func (c *containerAttachContext) AttachToContainer(name string, uid types.UID, container string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remoteutils.TerminalSize, timeout time.Duration) error {
+func (c *containerAttachContext) AttachToContainer(
+	name string,
+	uid types.UID,
+	container string,
+	in io.Reader,
+	out, err io.WriteCloser,
+	tty bool,
+	resize <-chan remoteutils.TerminalSize,
+	timeout time.Duration,
+) error {
 
 	eio := &execIO{
 		tty:    tty,

--- a/node/api/exec.go
+++ b/node/api/exec.go
@@ -171,7 +171,17 @@ type containerExecContext struct {
 
 // ExecInContainer Implements remotecommand.Executor
 // This is called by remotecommand.ServeExec
-func (c *containerExecContext) ExecInContainer(name string, uid types.UID, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remoteutils.TerminalSize, timeout time.Duration) error {
+func (c *containerExecContext) ExecInContainer(
+	name string,
+	uid types.UID,
+	container string,
+	cmd []string,
+	in io.Reader,
+	out, err io.WriteCloser,
+	tty bool,
+	resize <-chan remoteutils.TerminalSize,
+	timeout time.Duration,
+) error {
 
 	eio := &execIO{
 		tty:    tty,


### PR DESCRIPTION
Previously 'lll' linter was configured to .golangci.yml but with a typo in the directive ('linter-settings', not 'linters-settings').

Enable line length linter and fix long lines by breaking function signatures across multiple lines in exec.go, attach.go, and resource.go.