### PR TITLE
omit secret/configmap informers when `skipDownwardAPIResolution` is enabled

### DIFF
--- a/internal/manager/resource.go
+++ b/internal/manager/resource.go
@@ -15,6 +15,8 @@
 package manager
 
 import (
+	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -31,15 +33,30 @@ type ResourceManager struct {
 	serviceLister   corev1listers.ServiceLister
 }
 
+type ResourceManagerOption func(*ResourceManager)
+
 // NewResourceManager returns a ResourceManager with the internal maps initialized.
-func NewResourceManager(podLister corev1listers.PodLister, secretLister corev1listers.SecretLister, configMapLister corev1listers.ConfigMapLister, serviceLister corev1listers.ServiceLister) (*ResourceManager, error) {
+func NewResourceManager(podLister corev1listers.PodLister, serviceLister corev1listers.ServiceLister, opts ...ResourceManagerOption) (*ResourceManager, error) {
 	rm := ResourceManager{
-		podLister:       podLister,
-		secretLister:    secretLister,
-		configMapLister: configMapLister,
-		serviceLister:   serviceLister,
+		podLister:     podLister,
+		serviceLister: serviceLister,
+	}
+	for _, opt := range opts {
+		opt(&rm)
 	}
 	return &rm, nil
+}
+
+func WithSecretLister(secretLister corev1listers.SecretLister) ResourceManagerOption {
+	return func(rm *ResourceManager) {
+		rm.secretLister = secretLister
+	}
+}
+
+func WithConfigMapLister(configMapLister corev1listers.ConfigMapLister) ResourceManagerOption {
+	return func(rm *ResourceManager) {
+		rm.configMapLister = configMapLister
+	}
 }
 
 // GetPods returns a list of all known pods assigned to this virtual node.
@@ -54,11 +71,17 @@ func (rm *ResourceManager) GetPods() []*v1.Pod {
 
 // GetConfigMap retrieves the specified config map from the cache.
 func (rm *ResourceManager) GetConfigMap(name, namespace string) (*v1.ConfigMap, error) {
+	if rm.configMapLister == nil {
+		return nil, fmt.Errorf("configmap lister is not enabled")
+	}
 	return rm.configMapLister.ConfigMaps(namespace).Get(name)
 }
 
 // GetSecret retrieves the specified secret from Kubernetes.
 func (rm *ResourceManager) GetSecret(name, namespace string) (*v1.Secret, error) {
+	if rm.secretLister == nil {
+		return nil, fmt.Errorf("secret lister is not enabled")
+	}
 	return rm.secretLister.Secrets(namespace).Get(name)
 }
 

--- a/node/podcontroller.go
+++ b/node/podcontroller.go
@@ -219,10 +219,10 @@ func NewPodController(cfg PodControllerConfig) (*PodController, error) {
 	if cfg.PodInformer == nil {
 		return nil, errdefs.InvalidInput("missing pod informer")
 	}
-	if cfg.ConfigMapInformer == nil {
+	if cfg.ConfigMapInformer == nil && !cfg.SkipDownwardAPIResolution {
 		return nil, errdefs.InvalidInput("missing config map informer")
 	}
-	if cfg.SecretInformer == nil {
+	if cfg.SecretInformer == nil && !cfg.SkipDownwardAPIResolution {
 		return nil, errdefs.InvalidInput("missing secret informer")
 	}
 	if cfg.ServiceInformer == nil {
@@ -240,7 +240,11 @@ func NewPodController(cfg PodControllerConfig) (*PodController, error) {
 	if cfg.SyncPodStatusFromProviderRateLimiter == nil {
 		cfg.SyncPodStatusFromProviderRateLimiter = workqueue.DefaultTypedControllerRateLimiter[any]()
 	}
-	rm, err := manager.NewResourceManager(cfg.PodInformer.Lister(), cfg.SecretInformer.Lister(), cfg.ConfigMapInformer.Lister(), cfg.ServiceInformer.Lister())
+	var opts []manager.ResourceManagerOption
+	if !cfg.SkipDownwardAPIResolution {
+		opts = append(opts, manager.WithConfigMapLister(cfg.ConfigMapInformer.Lister()), manager.WithSecretLister(cfg.SecretInformer.Lister()))
+	}
+	rm, err := manager.NewResourceManager(cfg.PodInformer.Lister(), cfg.ServiceInformer.Lister(), opts...)
 	if err != nil {
 		return nil, pkgerrors.Wrap(err, "could not create resource manager")
 	}


### PR DESCRIPTION
It appears these informers aren't used when `skipDownwardAPIResolution` is enabled. This would help save on unused memory. 

TODO: testing