### PR TITLE
test: replace kubebuilder with envtest (2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ credentials.json
 # Test loganalytics file
 loganalytics.json
 
+# Envtest
+.envtest/
+
 # VS Code files
 .vscode/
 

--- a/Makefile
+++ b/Makefile
@@ -165,19 +165,18 @@ authors:
 	rm -f NEWAUTHORS
 	rm -f GITAUTHORS
 
-checksums_2.3.1.txt:
-	curl -o checksums_2.3.1.txt -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/checksums.txt
-kubebuilder_2.3.1_${TEST_OS}_${TEST_ARCH}.tar.gz:
-	curl -C - -O -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_${TEST_OS}_${TEST_ARCH}.tar.gz
-kubebuilder_2.3.1_${TEST_OS}_${TEST_ARCH}: kubebuilder_2.3.1_${TEST_OS}_${TEST_ARCH}.tar.gz checksums_2.3.1.txt
-	sha256sum -c --ignore-missing checksums_2.3.1.txt
-	tar -xvf kubebuilder_2.3.1_${TEST_OS}_${TEST_ARCH}.tar.gz
+SETUP_ENVTEST_VERSION ?= v0.0.0-20250604165838-d6126d850224
+ENVTEST_K8S_VERSION := 1.31.x
+
+ENVTEST ?= go run sigs.k8s.io/controller-runtime/tools/setup-envtest@$(SETUP_ENVTEST_VERSION)
+ENVTEST_DIR ?= $(shell pwd)/.envtest
+export KUBEBUILDER_ASSETS ?= $(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_DIR) -p path)
 
 .PHONY: envtest
-envtest: kubebuilder_2.3.1_${TEST_OS}_${TEST_ARCH}
+envtest:
 	# You can add klog flags for debugging, like: -klog.v=10 -klog.logtostderr
 	# klogv2 flags just wraps our existing logrus.
-	KUBEBUILDER_ASSETS=$(PWD)/kubebuilder_2.3.1_${TEST_OS}_${TEST_ARCH}/bin $(GOTEST) -run=TestEnvtest ./node -envtest=true
+	$(GOTEST) -run=TestEnvtest ./node -envtest=true
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
This PR supersedes #1265, adding `envtest`, setting up the environment with `setup-envtest`.

In the [docs](https://pkg.go.dev/sigs.k8s.io/controller-runtime/tools/setup-envtest) they say to use the `latest` version with Go 1.24+, but I've pinned the [`v0.0.0-20250604165838-d6126d850224`](https://pkg.go.dev/sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20250604165838-d6126d850224) version, released few days ago (Jun 4, 2025).

Closes #1265