### PR TITLE
allow pod controller config overrides

### DIFF
--- a/node/nodeutil/provider.go
+++ b/node/nodeutil/provider.go
@@ -61,7 +61,7 @@ type NewProviderFunc func(ProviderConfig) (Provider, node.NodeProvider, error)
 // AttachProviderRoutes returns a NodeOpt which uses api.PodHandler to attach the routes to the provider functions.
 //
 // Note this only attaches routes, you'll need to ensure to set the handler in the node config.
-func AttachProviderRoutes(mux api.ServeMux) NodeOpt {
+func AttachProviderRoutes(mux api.ServeMux) NodeConfigOpt {
 	return func(cfg *NodeConfig) error {
 		cfg.routeAttacher = func(p Provider, cfg NodeConfig, pods corev1listers.PodLister) {
 			mux.Handle("/", api.PodHandler(api.PodHandlerConfig{

--- a/node/nodeutil/tls.go
+++ b/node/nodeutil/tls.go
@@ -9,7 +9,7 @@ import (
 
 // WithTLSConfig returns a NodeOpt which creates a base TLSConfig with the default cipher suites and tls min verions.
 // The tls config can be modified through functional options.
-func WithTLSConfig(opts ...func(*tls.Config) error) NodeOpt {
+func WithTLSConfig(opts ...func(*tls.Config) error) NodeConfigOpt {
 	return func(cfg *NodeConfig) error {
 		tlsCfg := &tls.Config{
 			MinVersion:               tls.VersionTLS12,


### PR DESCRIPTION
Allow overriding pod controller config options

Current use-case is for `SyncPodsFromKubernetesRateLimiter`+`SyncPodsFromKubernetesShouldRetryFunc` -- specifically to infinitely retry for certain errors instead of stopping at 20 attempts (e.g. similar to `ImagePullBackoff`)