### PR TITLE
Remove documentation of Helm charts

### DIFF
--- a/website/content/docs/usage.md
+++ b/website/content/docs/usage.md
@@ -4,7 +4,7 @@ description: Run a Virtual Kubelet either on or external to a Kubernetes cluster
 weight: 2
 ---
 
-You can Virtual Kubelet either [on](#on-k8s) or [external](#external-k8s) to a Kubernetes cluster using the [`virtual-kubelet`](#virtual-kubelet-cli) command-line tool. If you run Virtual Kubelet on a Kubernetes cluster, you can also deploy it using [Helm](#helm).
+You can Virtual Kubelet either [on](#on-k8s) or [external](#external-k8s) to a Kubernetes cluster using the [`virtual-kubelet`](#virtual-kubelet-cli) command-line tool.
 
 > For `virtual-kubelet` installation instructions, see the [Setup](../setup) guide.
 
@@ -54,40 +54,3 @@ make skaffold MODE=run
 
 This will build and deploy the Virtual Kubelet and return.
 
-## Helm
-
-{{< info >}}
-[Helm](https://helm.sh) is a package manager that enables you to easily deploy complex systems on Kubernetes using configuration bundles called [Charts](https://docs.helm.sh/developing_charts/).
-{{< /info >}}
-
-You can use the Virtual Kubelet [Helm chart](https://github.com/virtual-kubelet/virtual-kubelet/tree/master/charts) to deploy Virtual Kubelet on Kubernetes.
-
-First, add the Chart repository (the Chart is currently hosted on [GitHub](https://github.com)):
-
-```bash
-helm repo add virtual-kubelet \
-  https://raw.githubusercontent.com/virtual-kubelet/virtual-kubelet/master/charts
-```
-
-{{< success >}}
-You can check to make sure that the repo is listed amongst your current repos using `helm repo list`.
-{{< /success >}}
-
-Now you can install Virtual Kubelet using `helm install`. Here's an example command:
-
-```bash
-helm install virtual-kubelet/virtual-kubelet \
-  --name virtual-kubelet-azure \
-  --namespace virtual-kubelet \
-  --set provider=azure
-```
-
-This would install the [Azure Container Instances Virtual Kubelet](https://github.com/virtual-kubelet/virtual-kubelet/tree/master/providers/azure) in the `virtual-kubelet` namespace.
-
-To verify that Virtual Kubelet has been installed, run this command, which will list the available nodes and watch for changes:
-
-```bash
-kubectl get nodes \
-  --namespace virtual-kubelet \
-  --watch
-```


### PR DESCRIPTION
Helm charts were removed by 731d0d6f5c (5 years ago). This commit just removed missleading documentation.