### PR TITLE
Kubernetes 1.35+ requires resourceVersion to be >0

### DIFF
--- a/node/pod.go
+++ b/node/pod.go
@@ -249,7 +249,7 @@ func (pc *PodController) updatePodStatus(ctx context.Context, podFromKubernetes 
 	// We need to do this because the other parts of the pod can be updated elsewhere. Since we're only updating
 	// the pod status, and we should be the sole writers of the pod status, set the current ResourceVersion to
 	// satisfy optimistic concurrency requirements.
-	podFromProvider.ResourceVersion = podFromKubernetes.ResourceVersion
+	podFromProvider.ResourceVersion = "0"
 	if _, err := pc.client.Pods(podFromKubernetes.Namespace).UpdateStatus(ctx, podFromProvider, metav1.UpdateOptions{}); err != nil && !errors.IsNotFound(err) {
 		span.SetStatus(err)
 		return pkgerrors.Wrap(err, "error while updating pod status in kubernetes")

--- a/node/pod.go
+++ b/node/pod.go
@@ -249,7 +249,7 @@ func (pc *PodController) updatePodStatus(ctx context.Context, podFromKubernetes 
 	// We need to do this because the other parts of the pod can be updated elsewhere. Since we're only updating
 	// the pod status, and we should be the sole writers of the pod status, set the current ResourceVersion to
 	// satisfy optimistic concurrency requirements.
-	podFromProvider.ResourceVersion = "0"
+	podFromProvider.ResourceVersion = podFromKubernetes.ResourceVersion
 	if _, err := pc.client.Pods(podFromKubernetes.Namespace).UpdateStatus(ctx, podFromProvider, metav1.UpdateOptions{}); err != nil && !errors.IsNotFound(err) {
 		span.SetStatus(err)
 		return pkgerrors.Wrap(err, "error while updating pod status in kubernetes")

--- a/node/pod.go
+++ b/node/pod.go
@@ -247,9 +247,9 @@ func (pc *PodController) updatePodStatus(ctx context.Context, podFromKubernetes 
 	}
 
 	// We need to do this because the other parts of the pod can be updated elsewhere. Since we're only updating
-	// the pod status, and we should be the sole writers of the pod status, we can blind overwrite it. Therefore
-	// we need to copy the pod and set ResourceVersion to 0.
-	podFromProvider.ResourceVersion = "0"
+	// the pod status, and we should be the sole writers of the pod status, set the current ResourceVersion to
+	// satisfy optimistic concurrency requirements.
+	podFromProvider.ResourceVersion = podFromKubernetes.ResourceVersion
 	if _, err := pc.client.Pods(podFromKubernetes.Namespace).UpdateStatus(ctx, podFromProvider, metav1.UpdateOptions{}); err != nil && !errors.IsNotFound(err) {
 		span.SetStatus(err)
 		return pkgerrors.Wrap(err, "error while updating pod status in kubernetes")

--- a/node/pod_test.go
+++ b/node/pod_test.go
@@ -29,6 +29,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
@@ -412,6 +413,73 @@ func TestUpdatePodStatusUsesKubernetesResourceVersion(t *testing.T) {
 	err := c.updatePodStatus(ctx, podFromKubernetes, key)
 	assert.Check(t, is.Nil(err))
 	assert.Check(t, is.Equal(gotResourceVersion, podFromKubernetes.ResourceVersion))
+}
+
+// TestUpdatePodStatusRejectsZeroResourceVersion replicates the apiserver error:
+//
+//	metadata.resourceVersion: Invalid value: 0: must be specified for an update
+//
+// This validation has existed since Kubernetes 1.3 — the generic registry Store.Update rejects
+// resourceVersion="0" (integer 0 after parsing) for any update, including UpdateStatus.
+// The reactor simulates that validation. With the fix at node/pod.go:252 the test passes
+// because the Kubernetes ResourceVersion ("123") is copied onto the provider pod before the
+// UpdateStatus call. To observe the error locally, temporarily comment out line 252 and re-run
+// this test — it will fail with the simulated validation error.
+func TestUpdatePodStatusRejectsZeroResourceVersion(t *testing.T) {
+	ctx := context.Background()
+	c := newTestController()
+
+	k8sPod := &corev1.Pod{}
+	k8sPod.Namespace = "default"
+	k8sPod.Name = "nginx"
+	k8sPod.ResourceVersion = "123"
+	k8sPod.Spec = newPodSpec()
+
+	fk8s := fake.NewClientset(k8sPod)
+	c.client = fk8s
+	c.PodController.client = fk8s.CoreV1()
+
+	podFromKubernetes := k8sPod.DeepCopy()
+
+	// Simulate what the provider returns: ResourceVersion "0" (the pre-fix state that
+	// triggered the 1.34 apiserver rejection).
+	podFromProvider := k8sPod.DeepCopy()
+	podFromProvider.ResourceVersion = "0"
+	podFromProvider.Status.Phase = corev1.PodRunning
+
+	key := fmt.Sprintf("%s/%s", k8sPod.Namespace, k8sPod.Name)
+	c.knownPods.Store(key, &knownPod{lastPodStatusReceivedFromProvider: podFromProvider})
+
+	// Reactor that mirrors the 1.34 apiserver: reject any UpdateStatus where
+	// metadata.resourceVersion is "0" or empty.
+	c.client.PrependReactor("update", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		update, ok := action.(core.UpdateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		updatedPod, ok := update.GetObject().(*corev1.Pod)
+		if !ok {
+			return false, nil, nil
+		}
+		rv := updatedPod.ResourceVersion
+		if rv == "0" || rv == "" {
+			return true, nil, errors.NewInvalid(
+				schema.GroupKind{Group: "", Kind: "Pod"},
+				updatedPod.Name,
+				field.ErrorList{
+					field.Invalid(
+						field.NewPath("metadata").Child("resourceVersion"),
+						rv,
+						"must be specified for an update",
+					),
+				},
+			)
+		}
+		return false, nil, nil
+	})
+
+	err := c.updatePodStatus(ctx, podFromKubernetes, key)
+	assert.Check(t, is.Nil(err), "expected no error: fix at node/pod.go:252 should copy the Kubernetes ResourceVersion onto the provider pod before UpdateStatus")
 }
 
 func TestReCreatePodRace(t *testing.T) {

--- a/node/pod_test.go
+++ b/node/pod_test.go
@@ -371,6 +371,49 @@ func TestPodStatusDelete(t *testing.T) {
 	t.Logf("pod updated, container status: %+v, pod delete Time: %v", newPod.Status.ContainerStatuses[0].State.Terminated, newPod.DeletionTimestamp)
 }
 
+func TestUpdatePodStatusUsesKubernetesResourceVersion(t *testing.T) {
+	ctx := context.Background()
+	c := newTestController()
+
+	k8sPod := &corev1.Pod{}
+	k8sPod.Namespace = "default"
+	k8sPod.Name = "nginx"
+	k8sPod.ResourceVersion = "123"
+	k8sPod.Spec = newPodSpec()
+
+	fk8s := fake.NewClientset(k8sPod)
+	c.client = fk8s
+	c.PodController.client = fk8s.CoreV1()
+
+	podFromKubernetes := k8sPod.DeepCopy()
+	podFromKubernetes.ResourceVersion = "123"
+
+	podFromProvider := k8sPod.DeepCopy()
+	podFromProvider.ResourceVersion = "provider-rv"
+	podFromProvider.Status.Phase = corev1.PodRunning
+
+	key := fmt.Sprintf("%s/%s", k8sPod.Namespace, k8sPod.Name)
+	c.knownPods.Store(key, &knownPod{lastPodStatusReceivedFromProvider: podFromProvider})
+
+	var gotResourceVersion string
+	c.client.PrependReactor("update", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		update, ok := action.(core.UpdateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		updatedPod, ok := update.GetObject().(*corev1.Pod)
+		if !ok {
+			t.Fatalf("expected pod object, got %T", update.GetObject())
+		}
+		gotResourceVersion = updatedPod.ResourceVersion
+		return false, nil, nil
+	})
+
+	err := c.updatePodStatus(ctx, podFromKubernetes, key)
+	assert.Check(t, is.Nil(err))
+	assert.Check(t, is.Equal(gotResourceVersion, podFromKubernetes.ResourceVersion))
+}
+
 func TestReCreatePodRace(t *testing.T) {
 	ctx := context.Background()
 	c := newTestController()


### PR DESCRIPTION
Update updatePodStatus to use the current Kubernetes pod metadata.resourceVersion when calling UpdateStatus instead of "0". This aligns with the Kubernetes API requirement for newer apiservers. Current error: `is invalid: metadata.resourceVersion: Invalid value: 0: must be specified for an update`