### PR TITLE
fix: ignore resolved env var ordering when comparing pods

### DIFF
--- a/node/pod.go
+++ b/node/pod.go
@@ -17,6 +17,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -86,7 +87,11 @@ func (pc *PodController) createOrUpdatePod(ctx context.Context, pod *corev1.Pod)
 	// NOTE: Some providers return a non-nil error in their GetPod implementation when the pod is not found while some other don't.
 	// Hence, we ignore the error and just act upon the pod if it is non-nil (meaning that the provider still knows about the pod).
 	if podFromProvider, _ := pc.provider.GetPod(ctx, pod.Namespace, pod.Name); podFromProvider != nil {
-		if !podsEqual(podFromProvider, podForProvider) {
+		podsEqualForProvider := podsEqual
+		if !pc.skipDownwardAPIResolution {
+			podsEqualForProvider = podsEqualWithResolvedEnvs
+		}
+		if !podsEqualForProvider(podFromProvider, podForProvider) {
 			log.G(ctx).Debugf("Pod %s exists, updating pod in provider", podFromProvider.Name)
 			if origErr := pc.provider.UpdatePod(ctx, podForProvider); origErr != nil {
 				pc.handleProviderError(ctx, span, origErr, pod)
@@ -130,6 +135,41 @@ func podsEqual(pod1, pod2 *corev1.Pod) bool {
 		cmp.Equal(pod1.Labels, pod2.Labels) &&
 		cmp.Equal(pod1.Annotations, pod2.Annotations)
 
+}
+
+func podsEqualWithResolvedEnvs(pod1, pod2 *corev1.Pod) bool {
+	pod1 = pod1.DeepCopy()
+	pod2 = pod2.DeepCopy()
+
+	for i := range pod1.Spec.Containers {
+		sortResolvedEnvVars(pod1.Spec.Containers[i].Env)
+	}
+	for i := range pod2.Spec.Containers {
+		sortResolvedEnvVars(pod2.Spec.Containers[i].Env)
+	}
+	for i := range pod1.Spec.InitContainers {
+		sortResolvedEnvVars(pod1.Spec.InitContainers[i].Env)
+	}
+	for i := range pod2.Spec.InitContainers {
+		sortResolvedEnvVars(pod2.Spec.InitContainers[i].Env)
+	}
+	for i := range pod1.Spec.EphemeralContainers {
+		sortResolvedEnvVars(pod1.Spec.EphemeralContainers[i].Env)
+	}
+	for i := range pod2.Spec.EphemeralContainers {
+		sortResolvedEnvVars(pod2.Spec.EphemeralContainers[i].Env)
+	}
+
+	return podsEqual(pod1, pod2)
+}
+
+func sortResolvedEnvVars(envs []corev1.EnvVar) {
+	sort.Slice(envs, func(i, j int) bool {
+		if envs[i].Name != envs[j].Name {
+			return envs[i].Name < envs[j].Name
+		}
+		return envs[i].Value < envs[j].Value
+	})
 }
 
 func deleteGraceTimeEqual(old, new *int64) bool {

--- a/node/pod_test.go
+++ b/node/pod_test.go
@@ -306,6 +306,48 @@ func TestPodNoSpecChange(t *testing.T) {
 	assert.Check(t, is.Equal(svr.mock.updates.read(), 0))
 }
 
+func TestPodNoSpecChangeWithResolvedEnvOrderDifference(t *testing.T) {
+	svr := newTestController()
+	svr.resourceManager = testutil.FakeResourceManager(testutil.FakeConfigMap("default", "pod-env", map[string]string{
+		"ALPHA": "1",
+		"BETA":  "2",
+	}))
+
+	pod := &corev1.Pod{}
+	pod.Namespace = "default"
+	pod.Name = "nginx"
+	pod.Spec = newPodSpec()
+	pod.Spec.EnableServiceLinks = boolPtr(false)
+	pod.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{{
+		ConfigMapRef: &corev1.ConfigMapEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "pod-env"},
+		},
+	}}
+
+	err := svr.createOrUpdatePod(context.Background(), pod.DeepCopy())
+	assert.Check(t, is.Nil(err))
+	assert.Check(t, is.Equal(svr.mock.creates.read(), 1))
+	assert.Check(t, is.Equal(svr.mock.updates.read(), 0))
+
+	key, err := buildKey(pod)
+	assert.Check(t, is.Nil(err))
+	createdPod, ok := svr.mock.pods.Load(key)
+	assert.Check(t, ok)
+
+	storedPod := createdPod.(*corev1.Pod).DeepCopy()
+	storedPod.Spec.Containers[0].Env = []corev1.EnvVar{
+		storedPod.Spec.Containers[0].Env[1],
+		storedPod.Spec.Containers[0].Env[0],
+	}
+	svr.mock.pods.Store(key, storedPod)
+
+	err = svr.createOrUpdatePod(context.Background(), pod.DeepCopy())
+	assert.Check(t, is.Nil(err))
+
+	assert.Check(t, is.Equal(svr.mock.creates.read(), 1))
+	assert.Check(t, is.Equal(svr.mock.updates.read(), 0))
+}
+
 func TestPodStatusDelete(t *testing.T) {
 	ctx := context.Background()
 	c := newTestController()
@@ -669,4 +711,8 @@ func newPodSpec() corev1.PodSpec {
 			},
 		},
 	}
+}
+
+func boolPtr(v bool) *bool {
+	return &v
 }


### PR DESCRIPTION
Small fix for a noisy update path.

When VK resolves env from `envFrom`, the provider compare can treat the same env set as different if the order comes back shuffled. Then we call `UpdatePod` again for no real spec change, kinda noisy.

Repro:
1. Create a pod that gets env via `envFrom`.
2. Have `GetPod` return the same env vars in a different order.
3. Reconcile the same pod again.
4. Before this patch VK calls `UpdatePod`.
5. After this patch it does not.

Why this is real:
Providers can round-trip env through unordered forms. `virtual-kubelet/openstack-zun` already flattens container env into `map[string]string` on create, so order loss is a real class of behavior, not just a toy test.

Tests:
- added a regression test for the reordered env case
- `go test ./...`
- `go test -race ./node/... ./internal/podutils/...`