### PR TITLE
fix: cancel exec/attach context when the streaming connection closes

### DIFF
--- a/internal/kubernetes/remotecommand/attach.go
+++ b/internal/kubernetes/remotecommand/attach.go
@@ -41,13 +41,17 @@ type Attacher interface {
 // ServeAttach handles requests to attach to a container. After
 // creating/receiving the required streams, it delegates the actual attachment
 // to the attacher.
-func ServeAttach(w http.ResponseWriter, req *http.Request, attacher Attacher, podName string, uid types.UID, container string, streamOpts *Options, idleTimeout, streamCreationTimeout time.Duration, supportedProtocols []string) {
+func ServeAttach(w http.ResponseWriter, req *http.Request, attacher Attacher, cancel func(), podName string, uid types.UID, container string, streamOpts *Options, idleTimeout, streamCreationTimeout time.Duration, supportedProtocols []string) {
 	ctx, ok := createStreams(req, w, streamOpts, supportedProtocols, idleTimeout, streamCreationTimeout)
 	if !ok {
 		// error is handled by createStreams
 		return
 	}
 	defer ctx.conn.Close()
+
+	execDone := make(chan struct{})
+	defer close(execDone)
+	go watchClose(closeChan(ctx.conn), execDone, cancel)
 
 	err := attacher.AttachToContainer(podName, uid, container, ctx.stdinStream, ctx.stdoutStream, ctx.stderrStream, ctx.tty, ctx.resizeChan, 0)
 	if err != nil {

--- a/internal/kubernetes/remotecommand/attach.go
+++ b/internal/kubernetes/remotecommand/attach.go
@@ -41,7 +41,7 @@ type Attacher interface {
 // ServeAttach handles requests to attach to a container. After
 // creating/receiving the required streams, it delegates the actual attachment
 // to the attacher.
-func ServeAttach(w http.ResponseWriter, req *http.Request, attacher Attacher, cancel func(), podName string, uid types.UID, container string, streamOpts *Options, idleTimeout, streamCreationTimeout time.Duration, supportedProtocols []string) {
+func ServeAttach(w http.ResponseWriter, req *http.Request, attacher Attacher, podName string, uid types.UID, container string, streamOpts *Options, idleTimeout, streamCreationTimeout time.Duration, supportedProtocols []string) {
 	ctx, ok := createStreams(req, w, streamOpts, supportedProtocols, idleTimeout, streamCreationTimeout)
 	if !ok {
 		// error is handled by createStreams
@@ -49,9 +49,14 @@ func ServeAttach(w http.ResponseWriter, req *http.Request, attacher Attacher, ca
 	}
 	defer ctx.conn.Close()
 
-	execDone := make(chan struct{})
-	defer close(execDone)
-	go watchClose(closeChan(ctx.conn), execDone, cancel)
+	// An attacher may opt into client-disconnect cancellation by implementing
+	// Cancel; closeChan fires it on a SPDY CloseChan. Inert on transports without
+	// a CloseChan (websocket observes disconnect via stream closure).
+	if canceler, ok := attacher.(interface{ Cancel() }); ok {
+		execDone := make(chan struct{})
+		defer close(execDone)
+		go watchClose(closeChan(ctx.conn), execDone, canceler.Cancel)
+	}
 
 	err := attacher.AttachToContainer(podName, uid, container, ctx.stdinStream, ctx.stdoutStream, ctx.stderrStream, ctx.tty, ctx.resizeChan, 0)
 	if err != nil {

--- a/internal/kubernetes/remotecommand/cancelwatch.go
+++ b/internal/kubernetes/remotecommand/cancelwatch.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import "io"
+
+// watchClose cancels an exec/attach context when the underlying connection's
+// close channel fires (a client disconnect or the stream idle-timeout), and
+// returns without cancelling when the exec/attach completes first (execDone).
+// A nil closeCh (e.g. the websocket transport, which has no CloseChan) is never
+// selected, so the watcher simply waits for execDone — never spuriously
+// cancelling. The goroutine always terminates once either channel fires.
+func watchClose(closeCh <-chan bool, execDone <-chan struct{}, cancel func()) {
+	select {
+	case <-closeCh:
+		cancel()
+	case <-execDone:
+	}
+}
+
+// closeChan returns the connection's close channel when conn exposes one (the
+// SPDY httpstream.Connection), or nil otherwise (the websocket conn is only an
+// io.Closer). Returning nil keeps the watcher inert on transports that cannot
+// report a mid-stream client drop, and avoids widening the context.conn field
+// (which would break the websocket assignment at compile time).
+func closeChan(conn io.Closer) <-chan bool {
+	if c, ok := conn.(interface{ CloseChan() <-chan bool }); ok {
+		return c.CloseChan()
+	}
+	return nil
+}

--- a/internal/kubernetes/remotecommand/cancelwatch.go
+++ b/internal/kubernetes/remotecommand/cancelwatch.go
@@ -22,7 +22,7 @@ import "io"
 // close channel fires (a client disconnect or the stream idle-timeout), and
 // returns without cancelling when the exec/attach completes first (execDone).
 // A nil closeCh (e.g. the websocket transport, which has no CloseChan) is never
-// selected, so the watcher simply waits for execDone — never spuriously
+// selected, so the watcher simply waits for execDone - never spuriously
 // cancelling. The goroutine always terminates once either channel fires.
 func watchClose(closeCh <-chan bool, execDone <-chan struct{}, cancel func()) {
 	select {

--- a/internal/kubernetes/remotecommand/cancelwatch_test.go
+++ b/internal/kubernetes/remotecommand/cancelwatch_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/httpstream"
+)
+
+// waitTimeout bounds how long a test waits for a goroutine signal before
+// declaring failure. It is only ever hit on a genuine bug (a never-fired
+// cancel or a leaked goroutine), so it can be generous without slowing the
+// happy path.
+const waitTimeout = time.Second
+
+// TestWatchClose_CancelOnClose verifies that watchClose calls cancel exactly
+// once and returns when the connection close channel fires. This is the
+// load-bearing case: a hard client drop closes closeCh, and the server-side
+// exec/attach context must be cancelled so the provider can reap the remote
+// process.
+func TestWatchClose_CancelOnClose(t *testing.T) {
+	for name, closer := range map[string]func(ch chan bool){
+		"closeCh closed":         func(ch chan bool) { close(ch) },
+		"closeCh receives value": func(ch chan bool) { ch <- true },
+	} {
+		t.Run(name, func(t *testing.T) {
+			closeCh := make(chan bool)
+			execDone := make(chan struct{})
+
+			// cancelled is closed by the cancel func, giving a race-safe
+			// happens-before edge instead of a shared bool.
+			cancelled := make(chan struct{})
+			cancelCount := make(chan struct{}, 8)
+			cancel := func() {
+				cancelCount <- struct{}{}
+				select {
+				case <-cancelled:
+					// already closed by an earlier call; closing again would panic.
+				default:
+					close(cancelled)
+				}
+			}
+
+			returned := make(chan struct{})
+			go func() {
+				watchClose(closeCh, execDone, cancel)
+				close(returned)
+			}()
+
+			closer(closeCh)
+
+			select {
+			case <-cancelled:
+			case <-time.After(waitTimeout):
+				t.Fatal("cancel was not called after closeCh fired")
+			}
+
+			// watchClose must return after cancelling so its goroutine does not leak.
+			select {
+			case <-returned:
+			case <-time.After(waitTimeout):
+				t.Fatal("watchClose did not return after cancelling")
+			}
+
+			// cancel must fire exactly once.
+			if got := len(cancelCount); got != 1 {
+				t.Errorf("expected cancel to be called exactly once, got %d calls", got)
+			}
+		})
+	}
+}
+
+// TestWatchClose_ExecDoneFirst_NoCancel verifies that when the exec/attach
+// finishes normally (execDone closes first), watchClose returns WITHOUT
+// calling cancel. Cancelling here would be a spurious cancellation of a
+// connection that is shutting down cleanly.
+func TestWatchClose_ExecDoneFirst_NoCancel(t *testing.T) {
+	closeCh := make(chan bool)
+	execDone := make(chan struct{})
+
+	cancelCount := make(chan struct{}, 8)
+	cancel := func() { cancelCount <- struct{}{} }
+
+	returned := make(chan struct{})
+	go func() {
+		watchClose(closeCh, execDone, cancel)
+		close(returned)
+	}()
+
+	close(execDone)
+
+	// watchClose must return promptly once execDone fires (no goroutine leak).
+	select {
+	case <-returned:
+	case <-time.After(waitTimeout):
+		t.Fatal("watchClose did not return after execDone closed")
+	}
+
+	// After the goroutine has provably exited, the cancel count is stable.
+	if got := len(cancelCount); got != 0 {
+		t.Errorf("expected cancel not to be called when execDone closes first, got %d calls", got)
+	}
+}
+
+// TestWatchClose_NilCloseCh verifies the websocket-safe path: when closeCh is
+// nil (the websocket conn has no CloseChan), watchClose must never select the
+// nil channel — it blocks on it harmlessly — and returns only when execDone
+// closes, without calling cancel or panicking.
+func TestWatchClose_NilCloseCh(t *testing.T) {
+	var closeCh chan bool // nil
+	execDone := make(chan struct{})
+
+	cancelCount := make(chan struct{}, 8)
+	cancel := func() { cancelCount <- struct{}{} }
+
+	returned := make(chan struct{})
+	go func() {
+		watchClose(closeCh, execDone, cancel)
+		close(returned)
+	}()
+
+	close(execDone)
+
+	select {
+	case <-returned:
+	case <-time.After(waitTimeout):
+		t.Fatal("watchClose did not return after execDone closed (nil closeCh)")
+	}
+
+	if got := len(cancelCount); got != 0 {
+		t.Errorf("expected cancel not to be called with a nil closeCh, got %d calls", got)
+	}
+}
+
+// TestCloseChan verifies the conn -> close-channel extraction gate.
+func TestCloseChan(t *testing.T) {
+	t.Run("CloseChan-capable conn returns its channel", func(t *testing.T) {
+		// fc.CloseChan() returns fc.closeCh; closeChan must hand back THAT
+		// channel (identity), so the watcher observes the real connection close.
+		fc := newFakeConn()
+		got := closeChan(fc)
+		if got == nil {
+			t.Fatal("expected a non-nil channel from a CloseChan-capable conn")
+		}
+
+		// Prove identity: closing the conn's channel must be observable through
+		// the channel closeChan returned.
+		close(fc.closeCh)
+		select {
+		case _, ok := <-got:
+			if ok {
+				t.Error("expected the returned channel to be the conn's CloseChan (closed), but it carried a value")
+			}
+		case <-time.After(waitTimeout):
+			t.Fatal("returned channel is not the conn's CloseChan: it did not observe the close")
+		}
+	})
+
+	t.Run("plain io.Closer returns nil", func(t *testing.T) {
+		// A websocket-style conn that is only an io.Closer (no CloseChan) must
+		// yield a nil channel so the watcher never spuriously cancels.
+		if got := closeChan(nopCloser{}); got != nil {
+			t.Errorf("expected nil channel for a plain io.Closer, got %v", got)
+		}
+	})
+}
+
+// nopCloser is a minimal io.Closer that does NOT implement CloseChan, modeling
+// the websocket transport path.
+type nopCloser struct{}
+
+func (nopCloser) Close() error { return nil }
+
+// fakeConn implements the full httpstream.Connection interface (including a
+// controllable CloseChan) so closeChan's type assertion succeeds against it.
+// The template matches internal/kubernetes/portforward/httpstream_test.go.
+type fakeConn struct {
+	closeCh chan bool
+}
+
+func newFakeConn() *fakeConn {
+	return &fakeConn{closeCh: make(chan bool)}
+}
+
+var _ httpstream.Connection = &fakeConn{}
+
+func (*fakeConn) CreateStream(headers http.Header) (httpstream.Stream, error) { return nil, nil }
+func (*fakeConn) Close() error                                                { return nil }
+func (f *fakeConn) CloseChan() <-chan bool                                    { return f.closeCh }
+func (*fakeConn) SetIdleTimeout(timeout time.Duration)                        {}
+func (*fakeConn) RemoveStreams(streams ...httpstream.Stream)                  {}

--- a/internal/kubernetes/remotecommand/exec.go
+++ b/internal/kubernetes/remotecommand/exec.go
@@ -41,7 +41,7 @@ type Executor interface {
 // ServeExec handles requests to execute a command in a container. After
 // creating/receiving the required streams, it delegates the actual execution
 // to the executor.
-func ServeExec(w http.ResponseWriter, req *http.Request, executor Executor, cancel func(), podName string, uid types.UID, container string, cmd []string, streamOpts *Options, idleTimeout, streamCreationTimeout time.Duration, supportedProtocols []string) {
+func ServeExec(w http.ResponseWriter, req *http.Request, executor Executor, podName string, uid types.UID, container string, cmd []string, streamOpts *Options, idleTimeout, streamCreationTimeout time.Duration, supportedProtocols []string) {
 	ctx, ok := createStreams(req, w, streamOpts, supportedProtocols, idleTimeout, streamCreationTimeout)
 	if !ok {
 		// error is handled by createStreams
@@ -49,9 +49,14 @@ func ServeExec(w http.ResponseWriter, req *http.Request, executor Executor, canc
 	}
 	defer ctx.conn.Close()
 
-	execDone := make(chan struct{})
-	defer close(execDone)
-	go watchClose(closeChan(ctx.conn), execDone, cancel)
+	// An executor may opt into client-disconnect cancellation by implementing
+	// Cancel; closeChan fires it on a SPDY CloseChan. Inert on transports without
+	// a CloseChan (websocket observes disconnect via stream closure).
+	if canceler, ok := executor.(interface{ Cancel() }); ok {
+		execDone := make(chan struct{})
+		defer close(execDone)
+		go watchClose(closeChan(ctx.conn), execDone, canceler.Cancel)
+	}
 
 	err := executor.ExecInContainer(podName, uid, container, cmd, ctx.stdinStream, ctx.stdoutStream, ctx.stderrStream, ctx.tty, ctx.resizeChan, 0)
 	if err != nil {

--- a/internal/kubernetes/remotecommand/exec.go
+++ b/internal/kubernetes/remotecommand/exec.go
@@ -41,13 +41,17 @@ type Executor interface {
 // ServeExec handles requests to execute a command in a container. After
 // creating/receiving the required streams, it delegates the actual execution
 // to the executor.
-func ServeExec(w http.ResponseWriter, req *http.Request, executor Executor, podName string, uid types.UID, container string, cmd []string, streamOpts *Options, idleTimeout, streamCreationTimeout time.Duration, supportedProtocols []string) {
+func ServeExec(w http.ResponseWriter, req *http.Request, executor Executor, cancel func(), podName string, uid types.UID, container string, cmd []string, streamOpts *Options, idleTimeout, streamCreationTimeout time.Duration, supportedProtocols []string) {
 	ctx, ok := createStreams(req, w, streamOpts, supportedProtocols, idleTimeout, streamCreationTimeout)
 	if !ok {
 		// error is handled by createStreams
 		return
 	}
 	defer ctx.conn.Close()
+
+	execDone := make(chan struct{})
+	defer close(execDone)
+	go watchClose(closeChan(ctx.conn), execDone, cancel)
 
 	err := executor.ExecInContainer(podName, uid, container, cmd, ctx.stdinStream, ctx.stdoutStream, ctx.stderrStream, ctx.tty, ctx.resizeChan, 0)
 	if err != nil {

--- a/node/api/attach.go
+++ b/node/api/attach.go
@@ -69,12 +69,11 @@ func HandleContainerAttach(h ContainerAttachHandlerFunc, opts ...ContainerExecHa
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 
-		attach := &containerAttachContext{ctx: ctx, h: h, pod: pod, namespace: namespace, container: container}
+		attach := &containerAttachContext{ctx: ctx, cancel: cancel, h: h, pod: pod, namespace: namespace, container: container}
 		remotecommand.ServeAttach(
 			w,
 			req,
 			attach,
-			cancel,
 			"",
 			"",
 			container,
@@ -92,7 +91,12 @@ type containerAttachContext struct {
 	h                         ContainerAttachHandlerFunc
 	namespace, pod, container string
 	ctx                       context.Context
+	cancel                    context.CancelFunc
 }
+
+// Cancel is the opt-in hook remotecommand.ServeAttach type-asserts to cancel the
+// attach context on client disconnect.
+func (c *containerAttachContext) Cancel() { c.cancel() }
 
 // AttachToContainer Implements remotecommand.Attacher
 // This is called by remotecommand.ServeAttach

--- a/node/api/attach.go
+++ b/node/api/attach.go
@@ -74,6 +74,7 @@ func HandleContainerAttach(h ContainerAttachHandlerFunc, opts ...ContainerExecHa
 			w,
 			req,
 			attach,
+			cancel,
 			"",
 			"",
 			container,

--- a/node/api/exec.go
+++ b/node/api/exec.go
@@ -112,8 +112,7 @@ func HandleContainerExec(h ContainerExecHandlerFunc, opts ...ContainerExecHandle
 			return errdefs.AsInvalidInput(err)
 		}
 
-		// TODO: Why aren't we using req.Context() here?
-		ctx, cancel := context.WithCancel(context.TODO())
+		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 
 		exec := &containerExecContext{ctx: ctx, h: h, pod: pod, namespace: namespace, container: container}
@@ -121,6 +120,7 @@ func HandleContainerExec(h ContainerExecHandlerFunc, opts ...ContainerExecHandle
 			w,
 			req,
 			exec,
+			cancel,
 			"",
 			"",
 			container,

--- a/node/api/exec.go
+++ b/node/api/exec.go
@@ -115,12 +115,11 @@ func HandleContainerExec(h ContainerExecHandlerFunc, opts ...ContainerExecHandle
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 
-		exec := &containerExecContext{ctx: ctx, h: h, pod: pod, namespace: namespace, container: container}
+		exec := &containerExecContext{ctx: ctx, cancel: cancel, h: h, pod: pod, namespace: namespace, container: container}
 		remotecommand.ServeExec(
 			w,
 			req,
 			exec,
-			cancel,
 			"",
 			"",
 			container,
@@ -167,7 +166,12 @@ type containerExecContext struct {
 	h                         ContainerExecHandlerFunc
 	namespace, pod, container string
 	ctx                       context.Context
+	cancel                    context.CancelFunc
 }
+
+// Cancel is the opt-in hook remotecommand.ServeExec type-asserts to cancel the
+// exec context on client disconnect.
+func (c *containerExecContext) Cancel() { c.cancel() }
 
 // ExecInContainer Implements remotecommand.Executor
 // This is called by remotecommand.ServeExec

--- a/node/api/exec_attach_test.go
+++ b/node/api/exec_attach_test.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestContainerExecContext_CancelCancelsHandlerContext(t *testing.T) {
+	parent, parentCancel := context.WithCancel(context.Background())
+	defer parentCancel()
+
+	gotCtx := make(chan context.Context, 1)
+
+	c := &containerExecContext{
+		ctx:       parent,
+		cancel:    parentCancel,
+		namespace: "ns",
+		pod:       "pod",
+		container: "c",
+		h: func(ctx context.Context, namespace, podName, containerName string, cmd []string, attach AttachIO) error {
+			gotCtx <- ctx
+			return nil
+		},
+	}
+
+	if err := c.ExecInContainer("", "", "c", []string{"true"}, nil, nil, nil, false, nil, 0); err != nil {
+		t.Fatalf("ExecInContainer returned error: %v", err)
+	}
+
+	handlerCtx := <-gotCtx
+	if handlerCtx == nil {
+		t.Fatal("handler received nil context")
+	}
+
+	select {
+	case <-handlerCtx.Done():
+		t.Fatal("ctx cancelled prematurely")
+	default:
+	}
+
+	c.Cancel()
+
+	select {
+	case <-handlerCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("handler context not cancelled after Cancel()")
+	}
+}
+
+func TestContainerAttachContext_CancelCancelsHandlerContext(t *testing.T) {
+	parent, parentCancel := context.WithCancel(context.Background())
+	defer parentCancel()
+
+	gotCtx := make(chan context.Context, 1)
+
+	c := &containerAttachContext{
+		ctx:       parent,
+		cancel:    parentCancel,
+		namespace: "ns",
+		pod:       "pod",
+		container: "c",
+		h: func(ctx context.Context, namespace, podName, containerName string, attach AttachIO) error {
+			gotCtx <- ctx
+			return nil
+		},
+	}
+
+	if err := c.AttachToContainer("", "", "c", nil, nil, nil, false, nil, 0); err != nil {
+		t.Fatalf("AttachToContainer returned error: %v", err)
+	}
+
+	handlerCtx := <-gotCtx
+	if handlerCtx == nil {
+		t.Fatal("handler received nil context")
+	}
+
+	select {
+	case <-handlerCtx.Done():
+		t.Fatal("ctx cancelled prematurely")
+	default:
+	}
+
+	c.Cancel()
+
+	select {
+	case <-handlerCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("handler context not cancelled after Cancel()")
+	}
+}


### PR DESCRIPTION
A kubectl exec/attach aborted by a hard client disconnect (a crash, network partition, or SIGKILL: anything without a graceful in-band stream half-close) never cancelled the server-side exec. `HandleContainerExec` rooted the context in `context.TODO()`, and since the streaming connection is hijacked, net/http does not cancel `req.Context()` when a hijacked connection drops. The remote process ran until pod deletion and kept its streaming session open the whole time.

This roots the exec/attach context in `req.Context()` and, once the streams are set up, watches the connection's `CloseChan()` (which fires on both a client disconnect and the stream idle-timeout), cancelling the context when it closes. The cancellation propagates into the provider's exec/attach call so it can stop the remote process. The watcher goroutine returns as soon as the exec/attach returns, so it doesn't leak.

`ServeExec`/`ServeAttach` keep their original signatures: cancellation is opt-in via a runtime `executor.(interface{ Cancel() })` / `attacher.(interface{ Cancel() })` assertion, so an adopter enables it by implementing `Cancel()` on the value it already passes, with no API break and no context threaded through the call. The connection's `CloseChan` is likewise read through a type assertion rather than by widening the `context.conn` field, so the WebSocket streaming path (whose connection has no `CloseChan`) still compiles. That path already observes client disconnects through stream closure, so leaving the watcher inert there is correct.

This fixes a leak in [macOS-vz-kubelet](https://github.com/agoda-com/macOS-vz-kubelet) (the project which I maintain), a virtual-kubelet provider that runs each pod inside a macOS VM and serves exec/attach by running the command in the guest over an SSH session. Without a cancel signal the provider had no way to know the client was gone, so an aborted exec left the guest process and its SSH session alive until the pod was deleted, and a run of aborts exhausted the guest sshd's session limit and blocked further exec and stats on that VM. With the context cancelling on disconnect, the provider signals the remote process and closes the session as soon as the client drops, which reaps the process and frees the session slot.
