### PR TITLE
fix: ignore envvar order when comparing Pods

### DIFF
--- a/node/pod.go
+++ b/node/pod.go
@@ -17,6 +17,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -86,7 +87,11 @@ func (pc *PodController) createOrUpdatePod(ctx context.Context, pod *corev1.Pod)
 	// NOTE: Some providers return a non-nil error in their GetPod implementation when the pod is not found while some other don't.
 	// Hence, we ignore the error and just act upon the pod if it is non-nil (meaning that the provider still knows about the pod).
 	if podFromProvider, _ := pc.provider.GetPod(ctx, pod.Namespace, pod.Name); podFromProvider != nil {
-		if !podsEqual(podFromProvider, podForProvider) {
+		podsEqualForProvider := podsEqual
+		if !pc.skipDownwardAPIResolution {
+			podsEqualForProvider = podsEqualWithResolvedEnvs
+		}
+		if !podsEqualForProvider(podFromProvider, podForProvider) {
 			log.G(ctx).Debugf("Pod %s exists, updating pod in provider", podFromProvider.Name)
 			if origErr := pc.provider.UpdatePod(ctx, podForProvider); origErr != nil {
 				pc.handleProviderError(ctx, span, origErr, pod)
@@ -130,6 +135,41 @@ func podsEqual(pod1, pod2 *corev1.Pod) bool {
 		cmp.Equal(pod1.Labels, pod2.Labels) &&
 		cmp.Equal(pod1.Annotations, pod2.Annotations)
 
+}
+
+func podsEqualWithResolvedEnvs(pod1, pod2 *corev1.Pod) bool {
+	pod1 = pod1.DeepCopy()
+	pod2 = pod2.DeepCopy()
+
+	for i := range pod1.Spec.Containers {
+		sortResolvedEnvVars(pod1.Spec.Containers[i].Env)
+	}
+	for i := range pod2.Spec.Containers {
+		sortResolvedEnvVars(pod2.Spec.Containers[i].Env)
+	}
+	for i := range pod1.Spec.InitContainers {
+		sortResolvedEnvVars(pod1.Spec.InitContainers[i].Env)
+	}
+	for i := range pod2.Spec.InitContainers {
+		sortResolvedEnvVars(pod2.Spec.InitContainers[i].Env)
+	}
+	for i := range pod1.Spec.EphemeralContainers {
+		sortResolvedEnvVars(pod1.Spec.EphemeralContainers[i].Env)
+	}
+	for i := range pod2.Spec.EphemeralContainers {
+		sortResolvedEnvVars(pod2.Spec.EphemeralContainers[i].Env)
+	}
+
+	return podsEqual(pod1, pod2)
+}
+
+func sortResolvedEnvVars(envs []corev1.EnvVar) {
+	sort.Slice(envs, func(i, j int) bool {
+		if envs[i].Name != envs[j].Name {
+			return envs[i].Name < envs[j].Name
+		}
+		return envs[i].Value < envs[j].Value
+	})
 }
 
 func deleteGraceTimeEqual(old, new *int64) bool {

--- a/node/pod_test.go
+++ b/node/pod_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/ptr"
 
 	testutil "github.com/virtual-kubelet/virtual-kubelet/internal/test/util"
 )
@@ -317,7 +318,7 @@ func TestPodNoSpecChangeWithResolvedEnvOrderDifference(t *testing.T) {
 	pod.Namespace = "default"
 	pod.Name = "nginx"
 	pod.Spec = newPodSpec()
-	pod.Spec.EnableServiceLinks = boolPtr(false)
+	pod.Spec.EnableServiceLinks = ptr.To(false)
 	pod.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{{
 		ConfigMapRef: &corev1.ConfigMapEnvSource{
 			LocalObjectReference: corev1.LocalObjectReference{Name: "pod-env"},
@@ -711,8 +712,4 @@ func newPodSpec() corev1.PodSpec {
 			},
 		},
 	}
-}
-
-func boolPtr(v bool) *bool {
-	return &v
 }

--- a/node/pod_test.go
+++ b/node/pod_test.go
@@ -306,6 +306,48 @@ func TestPodNoSpecChange(t *testing.T) {
 	assert.Check(t, is.Equal(svr.mock.updates.read(), 0))
 }
 
+func TestPodNoSpecChangeWithResolvedEnvOrderDifference(t *testing.T) {
+	svr := newTestController()
+	svr.resourceManager = testutil.FakeResourceManager(testutil.FakeConfigMap("default", "pod-env", map[string]string{
+		"ALPHA": "1",
+		"BETA":  "2",
+	}))
+
+	pod := &corev1.Pod{}
+	pod.Namespace = "default"
+	pod.Name = "nginx"
+	pod.Spec = newPodSpec()
+	pod.Spec.EnableServiceLinks = boolPtr(false)
+	pod.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{{
+		ConfigMapRef: &corev1.ConfigMapEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "pod-env"},
+		},
+	}}
+
+	err := svr.createOrUpdatePod(context.Background(), pod.DeepCopy())
+	assert.Check(t, is.Nil(err))
+	assert.Check(t, is.Equal(svr.mock.creates.read(), 1))
+	assert.Check(t, is.Equal(svr.mock.updates.read(), 0))
+
+	key, err := buildKey(pod)
+	assert.Check(t, is.Nil(err))
+	createdPod, ok := svr.mock.pods.Load(key)
+	assert.Check(t, ok)
+
+	storedPod := createdPod.(*corev1.Pod).DeepCopy()
+	storedPod.Spec.Containers[0].Env = []corev1.EnvVar{
+		storedPod.Spec.Containers[0].Env[1],
+		storedPod.Spec.Containers[0].Env[0],
+	}
+	svr.mock.pods.Store(key, storedPod)
+
+	err = svr.createOrUpdatePod(context.Background(), pod.DeepCopy())
+	assert.Check(t, is.Nil(err))
+
+	assert.Check(t, is.Equal(svr.mock.creates.read(), 1))
+	assert.Check(t, is.Equal(svr.mock.updates.read(), 0))
+}
+
 func TestPodStatusDelete(t *testing.T) {
 	ctx := context.Background()
 	c := newTestController()
@@ -669,4 +711,8 @@ func newPodSpec() corev1.PodSpec {
 			},
 		},
 	}
+}
+
+func boolPtr(v bool) *bool {
+	return &v
 }


### PR DESCRIPTION
Work by @immanuwell ❤️ (credits kept in commit) but their PR was pending due to review that was easy enough to work on from my side, therefore unblocking the next minor release with this fix.

Fixes #1424 